### PR TITLE
When the input size is a power of 2, use the radix-4 algorithm instead of mixed radix

### DIFF
--- a/benches/rustfft.rs
+++ b/benches/rustfft.rs
@@ -16,12 +16,18 @@ fn bench_fft(b: &mut Bencher, len: usize) {
 }
 
 // Powers of 2
-#[bench] fn complex_p2_00064(b: &mut Bencher) { bench_fft(b,    64); }
-#[bench] fn complex_p2_00256(b: &mut Bencher) { bench_fft(b,   256); }
-#[bench] fn complex_p2_01024(b: &mut Bencher) { bench_fft(b,  1024); }
-#[bench] fn complex_p2_04096(b: &mut Bencher) { bench_fft(b,  4096); }
+#[bench] fn complex_p2_00128(b: &mut Bencher) { bench_fft(b,    128); }
+#[bench] fn complex_p2_00512(b: &mut Bencher) { bench_fft(b,   512); }
+#[bench] fn complex_p2_02048(b: &mut Bencher) { bench_fft(b,  2048); }
 #[bench] fn complex_p2_08192(b: &mut Bencher) { bench_fft(b,  8192); }
-#[bench] fn complex_p2_16384(b: &mut Bencher) { bench_fft(b, 16384); }
+#[bench] fn complex_p2_32768(b: &mut Bencher) { bench_fft(b, 32768); }
+
+// Powers of 4
+#[bench] fn complex_p4_00064(b: &mut Bencher) { bench_fft(b,    64); }
+#[bench] fn complex_p4_00256(b: &mut Bencher) { bench_fft(b,   256); }
+#[bench] fn complex_p4_01024(b: &mut Bencher) { bench_fft(b,  1024); }
+#[bench] fn complex_p4_04096(b: &mut Bencher) { bench_fft(b,  4096); }
+#[bench] fn complex_p4_16384(b: &mut Bencher) { bench_fft(b, 16384); }
 
 // Powers of 7
 #[bench] fn complex_p7_00343(b: &mut Bencher) { bench_fft(b,   343); }

--- a/src/butterflies.rs
+++ b/src/butterflies.rs
@@ -22,6 +22,18 @@ pub unsafe fn butterfly_2<T>(data: &mut [Complex<T>], stride: usize,
     }
 }
 
+pub unsafe fn butterfly_2_single<T>(data: &mut [Complex<T>], stride: usize)
+                             where T: Num + Copy {
+    let idx_1 = 0usize;
+    let idx_2 = stride;
+
+    let temp = *data.get_unchecked(idx_2);
+    data.get_unchecked_mut(idx_2).re = data.get_unchecked(idx_1).re - temp.re;
+    data.get_unchecked_mut(idx_2).im = data.get_unchecked(idx_1).im - temp.im;
+    data.get_unchecked_mut(idx_1).re = data.get_unchecked(idx_1).re + temp.re;
+    data.get_unchecked_mut(idx_1).im = data.get_unchecked(idx_1).im + temp.im;
+}
+
 pub unsafe fn butterfly_3<T>(data: &mut [Complex<T>], stride: usize,
                              twiddles: &[Complex<T>], num_ffts: usize)
                              where T: Num + Copy + FromPrimitive {
@@ -95,6 +107,32 @@ pub unsafe fn butterfly_4<T>(data: &mut [Complex<T>], stride: usize,
         tw_idx_2 += 2 * stride;
         tw_idx_3 += 3 * stride;
         idx += 1;
+    }
+}
+
+pub unsafe fn butterfly_4_single<T>(data: &mut [Complex<T>], stride: usize, inverse: bool)
+                             where T: Num + Copy {
+    let mut scratch: [Complex<T>; 6] = [Zero::zero(); 6];
+
+    scratch[0] = *data.get_unchecked(stride);
+    scratch[1] = *data.get_unchecked(2 * stride);
+    scratch[2] = *data.get_unchecked(3 * stride);
+    scratch[5] = *data.get_unchecked(0) - scratch[1];
+    *data.get_unchecked_mut(0) = data.get_unchecked(0) + scratch[1];
+    scratch[3] = scratch[0] + scratch[2];
+    scratch[4] = scratch[0] - scratch[2];
+    *data.get_unchecked_mut(2 * stride) = data.get_unchecked(0) - scratch[3];
+    *data.get_unchecked_mut(0) = data.get_unchecked(0) + scratch[3];
+    if inverse {
+        data.get_unchecked_mut(stride).re = scratch[5].re - scratch[4].im;
+        data.get_unchecked_mut(stride).im = scratch[5].im + scratch[4].re;
+        data.get_unchecked_mut(3 * stride).re = scratch[5].re + scratch[4].im;
+        data.get_unchecked_mut(3 * stride).im = scratch[5].im - scratch[4].re;
+    } else {
+        data.get_unchecked_mut(stride).re = scratch[5].re + scratch[4].im;
+        data.get_unchecked_mut(stride).im = scratch[5].im - scratch[4].re;
+        data.get_unchecked_mut(3 * stride).re = scratch[5].re - scratch[4].im;
+        data.get_unchecked_mut(3 * stride).im = scratch[5].im + scratch[4].re;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,15 @@
 extern crate num;
 
 mod butterflies;
+mod mixed_radix;
+mod radix4;
 
-use num::{Complex, Zero, One, Float, Num, FromPrimitive, Signed};
+use num::{Complex, Zero, One, Float, FromPrimitive, Signed};
 use num::traits::cast;
 use std::f32;
 
-use butterflies::{butterfly_2, butterfly_3, butterfly_4, butterfly_5};
+use mixed_radix::cooley_tukey;
+use radix4::{execute_radix4, prepare_radix4};
 
 enum Algorithm<T> {
     MixedRadix(Vec<(usize, usize)>, Vec<Complex<T>>),
@@ -74,8 +77,8 @@ impl<T> FFT<T> where T: Signed + FromPrimitive + Copy {
 
         match self.algorithm {
             Algorithm::Radix4 => {
-                copy_data_for_radix4(signal.len(), signal, spectrum, 1, 0, 0);
-                radix_4(signal.len(),
+                prepare_radix4(signal.len(), signal, spectrum, 1, 0, 0);
+                execute_radix4(signal.len(),
                         spectrum,
                         1,
                         &self.twiddles[..],
@@ -90,143 +93,11 @@ impl<T> FFT<T> where T: Signed + FromPrimitive + Copy {
                              scratch,
                              self.inverse)
             }
-            Algorithm::Noop => copy_data(signal, spectrum, 1),
-        }
-    }
-}
-
-fn cooley_tukey<T>(signal: &[Complex<T>],
-                   spectrum: &mut [Complex<T>],
-                   stride: usize,
-                   twiddles: &[Complex<T>],
-                   factors: &[(usize, usize)],
-                   scratch: &mut [Complex<T>],
-                   inverse: bool) where T: Signed + FromPrimitive + Copy {
-    if let Some(&(n1, n2)) = factors.first() {
-        if n2 == 1 {
-            // we theoretically need to compute n1 ffts of size n2
-            // but n2 is 1, and a fft of size 1 is just a copy
-            copy_data(signal, spectrum, stride);
-        } else {
-            // Recursive call to perform n1 ffts of length n2
-            for i in 0..n1 {
-                cooley_tukey(&signal[i * stride..],
-                             &mut spectrum[i * n2..],
-                             stride * n1, twiddles, &factors[1..],
-                             scratch, inverse);
-            }
-        }
-
-        match n1 {
-            5 => unsafe { butterfly_5(spectrum, stride, twiddles, n2) },
-            4 => unsafe { butterfly_4(spectrum, stride, twiddles, n2, inverse) },
-            3 => unsafe { butterfly_3(spectrum, stride, twiddles, n2) },
-            2 => unsafe { butterfly_2(spectrum, stride, twiddles, n2) },
-            _ => butterfly(spectrum, stride, twiddles, n2, n1, &mut scratch[..n1]),
-        }
-    }
-}
-
-fn radix_4<T>(size: usize,
-              spectrum: &mut [Complex<T>],
-              stride: usize,
-              twiddles: &[Complex<T>],
-              inverse: bool) where T: Signed + FromPrimitive + Copy {
-    match size {
-        4 => unsafe { butterfly_4(spectrum, stride, twiddles, 1, inverse) },
-        2 => unsafe { butterfly_2(spectrum, stride, twiddles, 1) },
-        _ => {
-            for i in 0..4 {
-                radix_4(size / 4,
-                        &mut spectrum[i * (size / 4)..],
-                        stride * 4,
-                        twiddles,
-                        inverse);
-            }
-            unsafe { butterfly_4(spectrum, stride, twiddles, size / 4, inverse) };
-        }
-    }
-}
-
-fn butterfly<T: Num + Copy>(data: &mut [Complex<T>],
-                            stride: usize,
-                            twiddles: &[Complex<T>],
-                            num_ffts: usize,
-                            fft_len: usize,
-                            scratch: &mut [Complex<T>]) {
-    // for each fft we have to perform...
-    for fft_idx in 0..num_ffts {
-
-        // copy over data into scratch space
-        let mut data_idx = fft_idx;
-        for s in scratch.iter_mut() {
-            *s = unsafe { *data.get_unchecked(data_idx) };
-            data_idx += num_ffts;
-        }
-
-        // perfom the butterfly from the scratch space into the original buffer
-        let mut data_idx = fft_idx;
-        while data_idx < fft_len * num_ffts {
-            let out_sample = unsafe { data.get_unchecked_mut(data_idx) };
-            *out_sample = Zero::zero();
-            let mut twiddle_idx = 0usize;
-            for in_sample in scratch.iter() {
-                let twiddle = unsafe { twiddles.get_unchecked(twiddle_idx) };
-                *out_sample = *out_sample + in_sample * twiddle;
-                twiddle_idx += stride * data_idx;
-                if twiddle_idx >= twiddles.len() { twiddle_idx -= twiddles.len() }
-            }
-            data_idx += num_ffts;
-        }
-
-    }
-}
-
-fn copy_data<T: Copy>(signal: &[Complex<T>], spectrum: &mut [Complex<T>], stride: usize)
-{
-    let mut spectrum_idx = 0usize;
-    let mut signal_idx = 0usize;
-    while signal_idx < signal.len() {
-        unsafe {
-            *spectrum.get_unchecked_mut(spectrum_idx) = *signal.get_unchecked(signal_idx);
-        }
-        spectrum_idx += 1;
-        signal_idx += stride;
-    }
-}
-
-// TODO: we should be able to do this in a simple loop, rather than recursively, using bit reversal
-// the algorithm will be a little more complicated though due
-// to us potentially using radix 2 for one of the teps
-fn copy_data_for_radix4<T: Copy>(size: usize,
-                           signal: &[Complex<T>],
-                           spectrum: &mut [Complex<T>],
-                           stride: usize,
-                           signal_offset: usize,
-                           spectrum_offset: usize)
-{
-    match size {
-        4 => unsafe {
-            for i in 0..4 {
-                *spectrum.get_unchecked_mut(spectrum_offset + i) =
-                    *signal.get_unchecked(signal_offset + i * stride);
-            }
-        },
-        2 => unsafe {
-            for i in 0..2 {
-                *spectrum.get_unchecked_mut(spectrum_offset + i) =
-                    *signal.get_unchecked(signal_offset + i * stride);
-            }
-        },
-        _ => {
-            for i in 0..4 {
-                copy_data_for_radix4(size / 4,
-                                     signal,
-                                     spectrum,
-                                     stride * 4,
-                                     signal_offset + i * stride,
-                                     spectrum_offset + i * (size / 4));
-            }
+            Algorithm::Noop => {
+                for (source, destination) in signal.iter().zip(spectrum.iter_mut()) {
+                    *destination = *source;
+                }
+            },
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use num::traits::cast;
 use std::f32;
 
 use mixed_radix::cooley_tukey;
-use radix4::{execute_radix4, prepare_radix4};
+use radix4::process_radix4;
 
 enum Algorithm<T> {
     MixedRadix(Vec<(usize, usize)>, Vec<Complex<T>>),
@@ -77,8 +77,8 @@ impl<T> FFT<T> where T: Signed + FromPrimitive + Copy {
 
         match self.algorithm {
             Algorithm::Radix4 => {
-                prepare_radix4(signal.len(), signal, spectrum, 1, 0, 0);
-                execute_radix4(signal.len(),
+                process_radix4(signal.len(),
+                        signal,
                         spectrum,
                         1,
                         &self.twiddles[..],

--- a/src/mixed_radix.rs
+++ b/src/mixed_radix.rs
@@ -1,0 +1,49 @@
+
+use num::{Complex, FromPrimitive, Signed};
+
+use butterflies::{butterfly_2, butterfly_3, butterfly_4, butterfly_5, butterfly};
+
+pub fn cooley_tukey<T>(signal: &[Complex<T>],
+                   spectrum: &mut [Complex<T>],
+                   stride: usize,
+                   twiddles: &[Complex<T>],
+                   factors: &[(usize, usize)],
+                   scratch: &mut [Complex<T>],
+                   inverse: bool) where T: Signed + FromPrimitive + Copy {
+    if let Some(&(n1, n2)) = factors.first() {
+        if n2 == 1 {
+            // we theoretically need to compute n1 ffts of size n2
+            // but n2 is 1, and a fft of size 1 is just a copy
+            copy_data(signal, spectrum, stride);
+        } else {
+            // Recursive call to perform n1 ffts of length n2
+            for i in 0..n1 {
+                cooley_tukey(&signal[i * stride..],
+                             &mut spectrum[i * n2..],
+                             stride * n1, twiddles, &factors[1..],
+                             scratch, inverse);
+            }
+        }
+
+        match n1 {
+            5 => unsafe { butterfly_5(spectrum, stride, twiddles, n2) },
+            4 => unsafe { butterfly_4(spectrum, stride, twiddles, n2, inverse) },
+            3 => unsafe { butterfly_3(spectrum, stride, twiddles, n2) },
+            2 => unsafe { butterfly_2(spectrum, stride, twiddles, n2) },
+            _ => butterfly(spectrum, stride, twiddles, n2, n1, &mut scratch[..n1]),
+        }
+    }
+}
+
+fn copy_data<T: Copy>(signal: &[Complex<T>], spectrum: &mut [Complex<T>], stride: usize)
+{
+    let mut spectrum_idx = 0usize;
+    let mut signal_idx = 0usize;
+    while signal_idx < signal.len() {
+        unsafe {
+            *spectrum.get_unchecked_mut(spectrum_idx) = *signal.get_unchecked(signal_idx);
+        }
+        spectrum_idx += 1;
+        signal_idx += stride;
+    }
+}

--- a/src/radix4.rs
+++ b/src/radix4.rs
@@ -1,61 +1,106 @@
 use num::{Complex, FromPrimitive, Signed};
 
-use butterflies::{butterfly_2, butterfly_4};
+use butterflies::{butterfly_2_single, butterfly_4_single, butterfly_4};
 
-pub fn execute_radix4<T>(size: usize,
+pub fn process_radix4<T>(size: usize,
+              signal: &[Complex<T>],
               spectrum: &mut [Complex<T>],
               stride: usize,
               twiddles: &[Complex<T>],
               inverse: bool) where T: Signed + FromPrimitive + Copy {
-    match size {
-        4 => unsafe { butterfly_4(spectrum, stride, twiddles, 1, inverse) },
-        2 => unsafe { butterfly_2(spectrum, stride, twiddles, 1) },
-        _ => {
-            for i in 0..4 {
-                execute_radix4(size / 4,
-                        &mut spectrum[i * (size / 4)..],
-                        stride * 4,
-                        twiddles,
-                        inverse);
+
+    let num_bits = (size - 1).count_ones();
+
+    //first, perform the butterflies. the butterfly size depends on the input size
+    let mut current_size = if num_bits % 2 == 1 {
+        //the size is a power of 2, so we need to do size-2 butterflies, with a stride of size / 2
+        for (chunk_index, chunk) in spectrum.chunks_mut(2 * stride).enumerate() {
+            //copy the data from the signal into our chunk -- we improve cache friendliness by copying it right when we need it
+            for i in 0..2 {
+                let signal_index = reverse_bits_radix4(num_bits, chunk_index * 2 + i);
+                unsafe { *chunk.get_unchecked_mut(i * stride) =
+                    *signal.get_unchecked(signal_index * stride) }
             }
-            unsafe { butterfly_4(spectrum, stride, twiddles, size / 4, inverse) };
+
+            //perform the butterly on our newly copied data
+            unsafe { butterfly_2_single(chunk, stride) }
         }
+
+        //for the cross-ffts we want to to start off with a size of 8 (2 * 4)
+        8
+    }
+    else {
+        for (chunk_index, chunk) in spectrum.chunks_mut(4 * stride).enumerate() {
+            //copy the data from the signal into our chunk -- we improve cache friendliness by copying it right when we need it
+            for i in 0..4 {
+                let signal_index = reverse_bits_radix4(num_bits, chunk_index * 4 + i);
+                 unsafe { *chunk.get_unchecked_mut(i * stride) =
+                    *signal.get_unchecked(signal_index * stride) }
+            }
+
+            unsafe { butterfly_4_single(chunk, stride, inverse) }
+        }
+
+        //for the cross-ffts we want to to start off with a size of 16 (4 * 4)
+        16
+    };
+
+    //now, perform all the cross-FFTs, one "layer" at a time
+    while current_size <= size {
+        let group_stride = size / current_size;
+
+        for i in 0..group_stride {
+            unsafe { butterfly_4(&mut spectrum[i * current_size..], group_stride, twiddles, current_size / 4, inverse) }
+        }
+        current_size *= 4;
     }
 }
 
+fn reverse_bits_radix4(num_bits: u32, mut n: usize) -> usize {
+    let mut output = 0;
 
+    //for radix 4, we want to reverse the bits of n, in blocks of 2 bits at a time
+    //so 110110 becomes 100111
 
-// TODO: we should be able to do this in a simple loop, rather than recursively, using bit reversal
-// the algorithm will be a little more complicated though due
-// to us potentially using radix 2 for one of the teps
-pub fn prepare_radix4<T: Copy>(size: usize,
-                           signal: &[Complex<T>],
-                           spectrum: &mut [Complex<T>],
-                           stride: usize,
-                           signal_offset: usize,
-                           spectrum_offset: usize)
-{
-    match size {
-        4 => unsafe {
-            for i in 0..4 {
-                *spectrum.get_unchecked_mut(spectrum_offset + i) =
-                    *signal.get_unchecked(signal_offset + i * stride);
-            }
-        },
-        2 => unsafe {
-            for i in 0..2 {
-                *spectrum.get_unchecked_mut(spectrum_offset + i) =
-                    *signal.get_unchecked(signal_offset + i * stride);
-            }
-        },
-        _ => {
-            for i in 0..4 {
-                prepare_radix4(size / 4,
-                                     signal,
-                                     spectrum,
-                                     stride * 4,
-                                     signal_offset + i * stride,
-                                     spectrum_offset + i * (size / 4));
+    //for radix 2, num_bits will be odd. in this case, we want to reverse just a single bit in the last iteration
+    if num_bits %2 == 1 {
+        output |= n & 1;
+        n >>= 1;
+    }
+
+    //now copy 2 bits at a time from n into 
+    for _ in 0..num_bits/2 {
+        output <<= 2;
+        output |= n & 3;
+        n >>= 2;
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod test {
+    use super::reverse_bits_radix4;
+
+    #[test]
+    fn test_bit_reversal() {
+        //first tuple element is num bits, second is expected output
+        let test_list = vec![
+            (1, vec![0,1]),
+            (2, vec![0,1,2,3]),
+            (3, vec![0,4,1,5,2,6,3,7]),
+            (4, vec![0,4,8,12,1,5,9,13,2,6,10,14,3,7,11,15]),
+            (5, vec![0,16,4,20,8,24,12,28,1,17,5,21,9,25,13,29,   2,18,6,22,10,26,14,30,3,19,7,23,11,27,15,31]),
+        ];
+
+        for (num_bits, expected_list) in test_list {
+
+            // verify that the bit reversal function reorders the range 0..size into the expected output
+            for (result, e) in
+                    (0..expected_list.len())
+                    .map(|i| reverse_bits_radix4(num_bits, i))
+                    .zip(expected_list.iter()) {
+                assert_eq!(result, *e);
             }
         }
     }

--- a/src/radix4.rs
+++ b/src/radix4.rs
@@ -3,104 +3,75 @@ use num::{Complex, FromPrimitive, Signed};
 use butterflies::{butterfly_2_single, butterfly_4_single, butterfly_4};
 
 pub fn process_radix4<T>(size: usize,
-              signal: &[Complex<T>],
-              spectrum: &mut [Complex<T>],
-              stride: usize,
-              twiddles: &[Complex<T>],
-              inverse: bool) where T: Signed + FromPrimitive + Copy {
+                         signal: &[Complex<T>],
+                         spectrum: &mut [Complex<T>],
+                         stride: usize,
+                         twiddles: &[Complex<T>],
+                         inverse: bool)
+    where T: Signed + FromPrimitive + Copy
+{
 
+    prepare_radix4(size, signal, spectrum, stride);
+
+    // first, perform the butterflies. the butterfly size depends on the input size
     let num_bits = (size - 1).count_ones();
-
-    //first, perform the butterflies. the butterfly size depends on the input size
-    let mut current_size = if num_bits % 2 == 1 {
-        //the size is a power of 2, so we need to do size-2 butterflies, with a stride of size / 2
-        for (chunk_index, chunk) in spectrum.chunks_mut(2 * stride).enumerate() {
-            //copy the data from the signal into our chunk -- we improve cache friendliness by copying it right when we need it
-            for i in 0..2 {
-                let signal_index = reverse_bits_radix4(num_bits, chunk_index * 2 + i);
-                unsafe { *chunk.get_unchecked_mut(i * stride) =
-                    *signal.get_unchecked(signal_index * stride) }
-            }
-
-            //perform the butterly on our newly copied data
+    let mut current_size = if num_bits % 2 > 0 {
+        // the size is a power of 2, so we need to do size-2 butterflies, with a stride of size / 2
+        for chunk in spectrum.chunks_mut(2 * stride) {
             unsafe { butterfly_2_single(chunk, stride) }
         }
 
-        //for the cross-ffts we want to to start off with a size of 8 (2 * 4)
+        // for the cross-ffts we want to to start off with a size of 8 (2 * 4)
         8
-    }
-    else {
-        for (chunk_index, chunk) in spectrum.chunks_mut(4 * stride).enumerate() {
-            //copy the data from the signal into our chunk -- we improve cache friendliness by copying it right when we need it
-            for i in 0..4 {
-                let signal_index = reverse_bits_radix4(num_bits, chunk_index * 4 + i);
-                 unsafe { *chunk.get_unchecked_mut(i * stride) =
-                    *signal.get_unchecked(signal_index * stride) }
-            }
-
+    } else {
+        for chunk in spectrum.chunks_mut(4 * stride) {
             unsafe { butterfly_4_single(chunk, stride, inverse) }
         }
 
-        //for the cross-ffts we want to to start off with a size of 16 (4 * 4)
+        // for the cross-ffts we want to to start off with a size of 16 (4 * 4)
         16
     };
 
-    //now, perform all the cross-FFTs, one "layer" at a time
+    // now, perform all the cross-FFTs, one "layer" at a time
     while current_size <= size {
         let group_stride = size / current_size;
 
         for i in 0..group_stride {
-            unsafe { butterfly_4(&mut spectrum[i * current_size..], group_stride, twiddles, current_size / 4, inverse) }
+            unsafe {
+                butterfly_4(&mut spectrum[i * current_size..],
+                            group_stride,
+                            twiddles,
+                            current_size / 4,
+                            inverse)
+            }
         }
         current_size *= 4;
     }
 }
 
-fn reverse_bits_radix4(num_bits: u32, mut n: usize) -> usize {
-    let mut output = 0;
-
-    //for radix 4, we want to reverse the bits of n, in blocks of 2 bits at a time
-    //so 110110 becomes 100111
-
-    //for radix 2, num_bits will be odd. in this case, we want to reverse just a single bit in the last iteration
-    if num_bits %2 == 1 {
-        output |= n & 1;
-        n >>= 1;
-    }
-
-    //now copy 2 bits at a time from n into 
-    for _ in 0..num_bits/2 {
-        output <<= 2;
-        output |= n & 3;
-        n >>= 2;
-    }
-
-    output
-}
-
-#[cfg(test)]
-mod test {
-    use super::reverse_bits_radix4;
-
-    #[test]
-    fn test_bit_reversal() {
-        //first tuple element is num bits, second is expected output
-        let test_list = vec![
-            (1, vec![0,1]),
-            (2, vec![0,1,2,3]),
-            (3, vec![0,4,1,5,2,6,3,7]),
-            (4, vec![0,4,8,12,1,5,9,13,2,6,10,14,3,7,11,15]),
-            (5, vec![0,16,4,20,8,24,12,28,1,17,5,21,9,25,13,29,   2,18,6,22,10,26,14,30,3,19,7,23,11,27,15,31]),
-        ];
-
-        for (num_bits, expected_list) in test_list {
-
-            // verify that the bit reversal function reorders the range 0..size into the expected output
-            for (result, e) in
-                    (0..expected_list.len())
-                    .map(|i| reverse_bits_radix4(num_bits, i))
-                    .zip(expected_list.iter()) {
-                assert_eq!(result, *e);
+// after testing an iterative bit reversal algorithm, this recursive algorithm
+// was almost an order of magnitude faster at setting up
+fn prepare_radix4<T: Copy>(size: usize,
+                           signal: &[Complex<T>],
+                           spectrum: &mut [Complex<T>],
+                           stride: usize) {
+    match size {
+        4 => unsafe {
+            for i in 0..4 {
+                *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
+            }
+        },
+        2 => unsafe {
+            for i in 0..2 {
+                *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
+            }
+        },
+        _ => {
+            for i in 0..4 {
+                prepare_radix4(size / 4,
+                               &signal[i * stride..],
+                               &mut spectrum[i * (size / 4)..],
+                               stride * 4);
             }
         }
     }

--- a/src/radix4.rs
+++ b/src/radix4.rs
@@ -1,0 +1,62 @@
+use num::{Complex, FromPrimitive, Signed};
+
+use butterflies::{butterfly_2, butterfly_4};
+
+pub fn execute_radix4<T>(size: usize,
+              spectrum: &mut [Complex<T>],
+              stride: usize,
+              twiddles: &[Complex<T>],
+              inverse: bool) where T: Signed + FromPrimitive + Copy {
+    match size {
+        4 => unsafe { butterfly_4(spectrum, stride, twiddles, 1, inverse) },
+        2 => unsafe { butterfly_2(spectrum, stride, twiddles, 1) },
+        _ => {
+            for i in 0..4 {
+                execute_radix4(size / 4,
+                        &mut spectrum[i * (size / 4)..],
+                        stride * 4,
+                        twiddles,
+                        inverse);
+            }
+            unsafe { butterfly_4(spectrum, stride, twiddles, size / 4, inverse) };
+        }
+    }
+}
+
+
+
+// TODO: we should be able to do this in a simple loop, rather than recursively, using bit reversal
+// the algorithm will be a little more complicated though due
+// to us potentially using radix 2 for one of the teps
+pub fn prepare_radix4<T: Copy>(size: usize,
+                           signal: &[Complex<T>],
+                           spectrum: &mut [Complex<T>],
+                           stride: usize,
+                           signal_offset: usize,
+                           spectrum_offset: usize)
+{
+    match size {
+        4 => unsafe {
+            for i in 0..4 {
+                *spectrum.get_unchecked_mut(spectrum_offset + i) =
+                    *signal.get_unchecked(signal_offset + i * stride);
+            }
+        },
+        2 => unsafe {
+            for i in 0..2 {
+                *spectrum.get_unchecked_mut(spectrum_offset + i) =
+                    *signal.get_unchecked(signal_offset + i * stride);
+            }
+        },
+        _ => {
+            for i in 0..4 {
+                prepare_radix4(size / 4,
+                                     signal,
+                                     spectrum,
+                                     stride * 4,
+                                     signal_offset + i * stride,
+                                     spectrum_offset + i * (size / 4));
+            }
+        }
+    }
+}


### PR DESCRIPTION
When the input size is a power of 2, use the radix-4 algorithm instead of mixed radix.

I derived the radix 4 algorithm from the mixed-radix one, as it's just a special case where n2 is 4 every time. Compared to the mixed radix algorithm on power of 2 sizes, the radix 4 algorithm has a shallower call tree, fewer branches, and is more cache friendly.

Using the built-in benchmarks, this version runs about twice as fast as mixed radix on power of 2 sizes.
