### PR TITLE
Use Rader's Algorithm when the input's size is a prime number

### DIFF
--- a/benches/rustfft.rs
+++ b/benches/rustfft.rs
@@ -15,15 +15,6 @@ fn bench_fft(b: &mut Bencher, len: usize) {
     b.iter(|| {fft.process(&signal[..], &mut spectrum[..]);} );
 }
 
-fn bench_fft_with_setup(b: &mut Bencher, len: usize) {
-    b.iter(|| {
-    	let mut fft = rustfft::FFT::new(len, false);
-	    let signal = vec![Complex{re: 0.0, im: 0.0}; len];
-	    let mut spectrum = signal.clone();
-    	fft.process(&signal[..], &mut spectrum[..]);
-    } );
-}
-/*
 // Powers of 2
 #[bench] fn complex_p2_00128(b: &mut Bencher) { bench_fft(b,    128); }
 #[bench] fn complex_p2_00512(b: &mut Bencher) { bench_fft(b,   512); }
@@ -43,16 +34,14 @@ fn bench_fft_with_setup(b: &mut Bencher, len: usize) {
 #[bench] fn complex_p7_02401(b: &mut Bencher) { bench_fft(b,  2401); }
 #[bench] fn complex_p7_16807(b: &mut Bencher) { bench_fft(b, 16807); }
 
-// some random composite lengths
+// composite lengths
 #[bench] fn complex_composite_0100(b: &mut Bencher) { bench_fft(b,  100); }
 #[bench] fn complex_composite_0900(b: &mut Bencher) { bench_fft(b,  900); }
 #[bench] fn complex_composite_1000(b: &mut Bencher) { bench_fft(b, 1000); }
-#[bench] fn complex_composite_1260(b: &mut Bencher) { bench_fft(b, 1260); }*/
+#[bench] fn complex_composite_1260(b: &mut Bencher) { bench_fft(b, 1260); }
 
-#[bench] fn complex_prime_0211(b: &mut Bencher) { bench_fft(b, 211); }
+// Prime lengths
+#[bench] fn complex_prime_0097(b: &mut Bencher) { bench_fft(b, 97); }
+#[bench] fn complex_prime_0151(b: &mut Bencher) { bench_fft(b, 151); }
 #[bench] fn complex_prime_1009(b: &mut Bencher) { bench_fft(b, 1009); }
 #[bench] fn complex_prime_2017(b: &mut Bencher) { bench_fft(b, 2017); }
-
-#[bench] fn complex_prime_with_setup_0211(b: &mut Bencher) { bench_fft_with_setup(b, 211); }
-#[bench] fn complex_prime_with_setup_1009(b: &mut Bencher) { bench_fft_with_setup(b, 1009); }
-#[bench] fn complex_prime_with_setup_2017(b: &mut Bencher) { bench_fft_with_setup(b, 2017); }

--- a/benches/rustfft.rs
+++ b/benches/rustfft.rs
@@ -15,6 +15,15 @@ fn bench_fft(b: &mut Bencher, len: usize) {
     b.iter(|| {fft.process(&signal[..], &mut spectrum[..]);} );
 }
 
+fn bench_fft_with_setup(b: &mut Bencher, len: usize) {
+    b.iter(|| {
+    	let mut fft = rustfft::FFT::new(len, false);
+	    let signal = vec![Complex{re: 0.0, im: 0.0}; len];
+	    let mut spectrum = signal.clone();
+    	fft.process(&signal[..], &mut spectrum[..]);
+    } );
+}
+/*
 // Powers of 2
 #[bench] fn complex_p2_00128(b: &mut Bencher) { bench_fft(b,    128); }
 #[bench] fn complex_p2_00512(b: &mut Bencher) { bench_fft(b,   512); }
@@ -34,9 +43,16 @@ fn bench_fft(b: &mut Bencher, len: usize) {
 #[bench] fn complex_p7_02401(b: &mut Bencher) { bench_fft(b,  2401); }
 #[bench] fn complex_p7_16807(b: &mut Bencher) { bench_fft(b, 16807); }
 
-// some other random lengths
-#[bench] fn complex_0100(b: &mut Bencher) { bench_fft(b,  100); }
-#[bench] fn complex_0900(b: &mut Bencher) { bench_fft(b,  900); }
-#[bench] fn complex_1000(b: &mut Bencher) { bench_fft(b, 1000); }
-#[bench] fn complex_1009(b: &mut Bencher) { bench_fft(b, 1009); }
-#[bench] fn complex_1260(b: &mut Bencher) { bench_fft(b, 1260); }
+// some random composite lengths
+#[bench] fn complex_composite_0100(b: &mut Bencher) { bench_fft(b,  100); }
+#[bench] fn complex_composite_0900(b: &mut Bencher) { bench_fft(b,  900); }
+#[bench] fn complex_composite_1000(b: &mut Bencher) { bench_fft(b, 1000); }
+#[bench] fn complex_composite_1260(b: &mut Bencher) { bench_fft(b, 1260); }*/
+
+#[bench] fn complex_prime_0211(b: &mut Bencher) { bench_fft(b, 211); }
+#[bench] fn complex_prime_1009(b: &mut Bencher) { bench_fft(b, 1009); }
+#[bench] fn complex_prime_2017(b: &mut Bencher) { bench_fft(b, 2017); }
+
+#[bench] fn complex_prime_with_setup_0211(b: &mut Bencher) { bench_fft_with_setup(b, 211); }
+#[bench] fn complex_prime_with_setup_1009(b: &mut Bencher) { bench_fft_with_setup(b, 1009); }
+#[bench] fn complex_prime_with_setup_2017(b: &mut Bencher) { bench_fft_with_setup(b, 2017); }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ impl<T> FFT<T> where T: Signed + FromPrimitive + Copy {
             }
             Algorithm::Raders(ref mut algorithm) => {
                 spectrum.copy_from_slice(signal);
-                algorithm.process(spectrum, 1);
+                algorithm.process(spectrum);
             }
             Algorithm::Noop => {
                 spectrum.copy_from_slice(signal);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,17 +42,23 @@ impl<T> FFT<T> where T: Signed + FromPrimitive + Copy {
             Algorithm::Noop
         } else if is_power_of_two(len) {
             Algorithm::Radix4
-        } else if false {
-            Algorithm::Raders(RadersAlgorithm::new(len, inverse))
         } else {
             let factors = factor(len);
-            let max_fft_len = factors.iter().map(|&(a, _)| a).max();
-            let scratch = match max_fft_len {
-                None | Some(0...5) => vec![Zero::zero(); 0],
-                Some(l) => vec![Zero::zero(); l],
-            };
 
-            Algorithm::MixedRadix(factors, scratch)
+            // benchmarking shows that raders algorithm isn't faster than the
+            // naive o(n^2) algorithm below around 200
+            if factors.len() == 1 && len > 200 {
+                //there is only one factor, meaning the input has a prime size
+                Algorithm::Raders(RadersAlgorithm::new(len, inverse))
+            } else {
+                let max_fft_len = factors.iter().map(|&(a, _)| a).max();
+                let scratch = match max_fft_len {
+                    None | Some(0...5) => vec![Zero::zero(); 0],
+                    Some(l) => vec![Zero::zero(); l],
+                };
+
+                Algorithm::MixedRadix(factors, scratch)
+            }
         };
 
         FFT {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ extern crate num;
 mod butterflies;
 mod mixed_radix;
 mod radix4;
+mod raders_algorithm;
+mod math_utils;
 
 use num::{Complex, Zero, One, Float, FromPrimitive, Signed};
 use num::traits::cast;
@@ -12,10 +14,12 @@ use std::f32;
 
 use mixed_radix::cooley_tukey;
 use radix4::process_radix4;
+use raders_algorithm::RadersAlgorithm;
 
 enum Algorithm<T> {
     MixedRadix(Vec<(usize, usize)>, Vec<Complex<T>>),
     Radix4,
+    Raders(RadersAlgorithm<T>),
     Noop,
 }
 
@@ -38,6 +42,8 @@ impl<T> FFT<T> where T: Signed + FromPrimitive + Copy {
             Algorithm::Noop
         } else if is_power_of_two(len) {
             Algorithm::Radix4
+        } else if false {
+            Algorithm::Raders(RadersAlgorithm::new(len, inverse))
         } else {
             let factors = factor(len);
             let max_fft_len = factors.iter().map(|&(a, _)| a).max();
@@ -93,10 +99,12 @@ impl<T> FFT<T> where T: Signed + FromPrimitive + Copy {
                              scratch,
                              self.inverse)
             }
+            Algorithm::Raders(ref mut algorithm) => {
+                spectrum.copy_from_slice(signal);
+                algorithm.process(spectrum, 1);
+            }
             Algorithm::Noop => {
-                for (source, destination) in signal.iter().zip(spectrum.iter_mut()) {
-                    *destination = *source;
-                }
+                spectrum.copy_from_slice(signal);
             },
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,8 @@ impl<T> FFT<T> where T: Signed + FromPrimitive + Copy {
             let factors = factor(len);
 
             // benchmarking shows that raders algorithm isn't faster than the
-            // naive o(n^2) algorithm below around 200
-            if factors.len() == 1 && len > 200 {
+            // naive o(n^2) algorithm below around 100
+            if factors.len() == 1 && len > 100 {
                 //there is only one factor, meaning the input has a prime size
                 Algorithm::Raders(RadersAlgorithm::new(len, inverse))
             } else {

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -7,7 +7,6 @@ pub fn primitive_root(prime: u64) -> Option<u64> {
 		.iter()
 		.map(|factor| (prime - 1) / factor)
 		.collect();
-
 	'next: for potential_root in 2..prime {
 		//for each distinct factor, if potential_root^(p-1)/factor mod p is 1, reject it
 		for exp in &test_exponents {
@@ -79,26 +78,29 @@ pub fn distinct_prime_factors(mut n: u64) -> Vec<u64> {
 		}
 		result.push(2);
 	}
+	if n > 1 {
+		let mut divisor = 3;
+		let mut limit = (n as f32).sqrt() as u64 + 1;
+		while divisor < limit {
+			if n % divisor == 0 {
 
-	let mut divisor = 3;
-	let mut limit = (n as f32).sqrt() as u64 + 1;
-	while divisor < limit {
-		if n % divisor == 0 {
+				//remove as many factors as possible from n
+				while n % divisor == 0 {
+					n /= divisor;
+				}
+				result.push(divisor);
 
-			//remove as many factors as possible from n
-			while n % divisor == 0 {
-				n /= divisor;
+				//recalculate the limit to reduce the amount of work we need to do
+				limit = (n as f32).sqrt() as u64 + 1;
 			}
-			result.push(divisor);
 
-			//recalculate the limit to reduce the amount of work we need to do
-			limit = (n as f32).sqrt() as u64 + 1;
+			divisor += 2;
 		}
 
-		divisor += 2;
+		if n > 1 {
+			result.push(n);
+		}
 	}
-
-	result.push(n);
 
 	result
 }
@@ -152,6 +154,7 @@ mod test {
 			];
 		
 		for (input, expected) in test_list {
+			println!("testing {}", input);
 			let root = primitive_root(input).unwrap();
 
 			assert_eq!(root, expected);
@@ -163,6 +166,9 @@ mod test {
 		println!("beginning of test");
 		let test_list = vec![
 			(46, vec![2,23]),
+			(2, vec![2]),
+			(3, vec![3]),
+			(162, vec![2, 3]),
 			];
 		
 		for (input, expected) in test_list {

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -3,178 +3,169 @@ use num::{Zero, One, FromPrimitive, Integer, PrimInt};
 use std::mem::swap;
 
 pub fn primitive_root(prime: u64) -> Option<u64> {
-	let test_exponents: Vec<u64> = distinct_prime_factors(prime - 1)
-		.iter()
-		.map(|factor| (prime - 1) / factor)
-		.collect();
-	'next: for potential_root in 2..prime {
-		//for each distinct factor, if potential_root^(p-1)/factor mod p is 1, reject it
-		for exp in &test_exponents {
-			if modular_exponent(potential_root, *exp, prime) == 1 {
-				continue 'next;
-			}
-		}
+    let test_exponents: Vec<u64> = distinct_prime_factors(prime - 1)
+        .iter()
+        .map(|factor| (prime - 1) / factor)
+        .collect();
+    'next: for potential_root in 2..prime {
+        // for each distinct factor, if potential_root^(p-1)/factor mod p is 1, reject it
+        for exp in &test_exponents {
+            if modular_exponent(potential_root, *exp, prime) == 1 {
+                continue 'next;
+            }
+        }
 
-		//if we reach this point, it means this root was not rejected, so return it
-		return Some(potential_root);
-	}
-	None
+        // if we reach this point, it means this root was not rejected, so return it
+        return Some(potential_root);
+    }
+    None
 }
 
 /// computes base^exponent % modulo using the standard exponentiation by squaring algorithm
 pub fn modular_exponent<T: PrimInt + Integer>(mut base: T, mut exponent: T, modulo: T) -> T {
-	let mut result = One::one();
+    let mut result = One::one();
 
-	while exponent > Zero::zero() {
-		if exponent.is_odd() {
-			result = result * base % modulo;
-		}
-		exponent = exponent >> One::one();
-		base = (base * base) % modulo;
-	}
+    while exponent > Zero::zero() {
+        if exponent.is_odd() {
+            result = result * base % modulo;
+        }
+        exponent = exponent >> One::one();
+        base = (base * base) % modulo;
+    }
 
-	result
+    result
 }
 
 pub fn multiplicative_inverse<T: PrimInt + Integer + FromPrimitive>(a: T, n: T) -> T {
-	// we're going to use a modified version extended euclidean algorithm
-	// we only need half the output
+    // we're going to use a modified version extended euclidean algorithm
+    // we only need half the output
 
-	let mut t = Zero::zero();
-	let mut t_new = One::one();
+    let mut t = Zero::zero();
+    let mut t_new = One::one();
 
-	let mut r = n;
-	let mut r_new = a;
+    let mut r = n;
+    let mut r_new = a;
 
-	while r_new > Zero::zero() {
-		let quotient = r / r_new;
+    while r_new > Zero::zero() {
+        let quotient = r / r_new;
 
-		r = r - quotient * r_new;
-		swap(&mut r, &mut r_new);
+        r = r - quotient * r_new;
+        swap(&mut r, &mut r_new);
 
-		//t might go negative here, so we have to do a checked subtract
-		//if it underflows, wrap it around to the other end of the modulo
-		//IE, 3 - 4 mod 5  =  -1 mod 5  =  4
-		let t_subtract = quotient * t_new;
-		t = if t_subtract < t {
-			t - t_subtract
-		} else {
-			n - (t_subtract - t) % n
-		};
-		swap(&mut t, &mut t_new);
-	}
+        // t might go negative here, so we have to do a checked subtract
+        // if it underflows, wrap it around to the other end of the modulo
+        // IE, 3 - 4 mod 5  =  -1 mod 5  =  4
+        let t_subtract = quotient * t_new;
+        t = if t_subtract < t {
+            t - t_subtract
+        } else {
+            n - (t_subtract - t) % n
+        };
+        swap(&mut t, &mut t_new);
+    }
 
-	t
+    t
 }
 
 /// return all of the prime factors of n, but omit duplicate prime factors
 pub fn distinct_prime_factors(mut n: u64) -> Vec<u64> {
-	let mut result = Vec::new();
+    let mut result = Vec::new();
 
-	//handle 2 separately so we dont have to worry about adding 2 vs 1
-	if n % 2 == 0 {
-		while n % 2 == 0 {
-			n /= 2;
-		}
-		result.push(2);
-	}
-	if n > 1 {
-		let mut divisor = 3;
-		let mut limit = (n as f32).sqrt() as u64 + 1;
-		while divisor < limit {
-			if n % divisor == 0 {
+    // handle 2 separately so we dont have to worry about adding 2 vs 1
+    if n % 2 == 0 {
+        while n % 2 == 0 {
+            n /= 2;
+        }
+        result.push(2);
+    }
+    if n > 1 {
+        let mut divisor = 3;
+        let mut limit = (n as f32).sqrt() as u64 + 1;
+        while divisor < limit {
+            if n % divisor == 0 {
 
-				//remove as many factors as possible from n
-				while n % divisor == 0 {
-					n /= divisor;
-				}
-				result.push(divisor);
+                // remove as many factors as possible from n
+                while n % divisor == 0 {
+                    n /= divisor;
+                }
+                result.push(divisor);
 
-				//recalculate the limit to reduce the amount of work we need to do
-				limit = (n as f32).sqrt() as u64 + 1;
-			}
+                // recalculate the limit to reduce the amount of work we need to do
+                limit = (n as f32).sqrt() as u64 + 1;
+            }
 
-			divisor += 2;
-		}
+            divisor += 2;
+        }
 
-		if n > 1 {
-			result.push(n);
-		}
-	}
+        if n > 1 {
+            result.push(n);
+        }
+    }
 
-	result
+    result
 }
 
 #[cfg(test)]
 mod test {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn test_modular_exponent() {
-		// make sure to test something that would overflow under ordinary circumstances
-		// ie 3 ^ 416788 mod 47
-		let test_list = vec![
+    #[test]
+    fn test_modular_exponent() {
+        // make sure to test something that would overflow under ordinary circumstances
+        // ie 3 ^ 416788 mod 47
+        let test_list = vec![
 			((2,8,300), 256),
 			((2,9,300), 212),
 			((1,9,300), 1),
 			((3,416788,47), 8),
 		];
-		
-		for (input, expected) in test_list {
-			let (base, exponent, modulo) = input;
 
-			let result = modular_exponent(base, exponent, modulo);
+        for (input, expected) in test_list {
+            let (base, exponent, modulo) = input;
 
-			assert_eq!(result, expected);
-		}
-	}
+            let result = modular_exponent(base, exponent, modulo);
 
-	#[test]
-	fn test_multiplicative_inverse() {
-		let prime_list = vec![3,5,7,11,13,17,19,23,29];
-		
-		for modulo in prime_list {
-			for i in 2..modulo {
-				let inverse = multiplicative_inverse(i, modulo);
+            assert_eq!(result, expected);
+        }
+    }
 
-				assert_eq!(i * inverse % modulo, 1);
-			}
-		}
-	}
+    #[test]
+    fn test_multiplicative_inverse() {
+        let prime_list = vec![3, 5, 7, 11, 13, 17, 19, 23, 29];
 
-	#[test]
-	fn test_primitive_root() {
-		let test_list = vec![
-			(3, 2),
-			(7, 3),
-			(11, 2),
-			(13, 2),
-			(47, 5),
-			(7919, 7)
-			];
-		
-		for (input, expected) in test_list {
-			println!("testing {}", input);
-			let root = primitive_root(input).unwrap();
+        for modulo in prime_list {
+            for i in 2..modulo {
+                let inverse = multiplicative_inverse(i, modulo);
 
-			assert_eq!(root, expected);
-		}
-	}
+                assert_eq!(i * inverse % modulo, 1);
+            }
+        }
+    }
 
-	#[test]
-	fn test_prime_factors() {
-		println!("beginning of test");
-		let test_list = vec![
+    #[test]
+    fn test_primitive_root() {
+        let test_list = vec![(3, 2), (7, 3), (11, 2), (13, 2), (47, 5), (7919, 7)];
+
+        for (input, expected) in test_list {
+            let root = primitive_root(input).unwrap();
+
+            assert_eq!(root, expected);
+        }
+    }
+
+    #[test]
+    fn test_prime_factors() {
+        let test_list = vec![
 			(46, vec![2,23]),
 			(2, vec![2]),
 			(3, vec![3]),
 			(162, vec![2, 3]),
 			];
-		
-		for (input, expected) in test_list {
-			let factors = distinct_prime_factors(input);
 
-			assert_eq!(factors, expected);
-		}
-	}
+        for (input, expected) in test_list {
+            let factors = distinct_prime_factors(input);
+
+            assert_eq!(factors, expected);
+        }
+    }
 }

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -1,0 +1,174 @@
+
+use num::{Zero, One, FromPrimitive, Integer, PrimInt};
+use std::mem::swap;
+
+pub fn primitive_root(prime: u64) -> Option<u64> {
+	let test_exponents: Vec<u64> = distinct_prime_factors(prime - 1)
+		.iter()
+		.map(|factor| (prime - 1) / factor)
+		.collect();
+
+	'next: for potential_root in 2..prime {
+		//for each distinct factor, if potential_root^(p-1)/factor mod p is 1, reject it
+		for exp in &test_exponents {
+			if modular_exponent(potential_root, *exp, prime) == 1 {
+				continue 'next;
+			}
+		}
+
+		//if we reach this point, it means this root was not rejected, so return it
+		return Some(potential_root);
+	}
+	None
+}
+
+/// computes base^exponent % modulo using the standard exponentiation by squaring algorithm
+pub fn modular_exponent<T: PrimInt + Integer>(mut base: T, mut exponent: T, modulo: T) -> T {
+	let mut result = One::one();
+
+	while exponent > Zero::zero() {
+		if exponent.is_odd() {
+			result = result * base % modulo;
+		}
+		exponent = exponent >> One::one();
+		base = (base * base) % modulo;
+	}
+
+	result
+}
+
+pub fn multiplicative_inverse<T: PrimInt + Integer + FromPrimitive>(a: T, n: T) -> T {
+	// we're going to use a modified version extended euclidean algorithm
+	// we only need half the output
+
+	let mut t = Zero::zero();
+	let mut t_new = One::one();
+
+	let mut r = n;
+	let mut r_new = a;
+
+	while r_new > Zero::zero() {
+		let quotient = r / r_new;
+
+		r = r - quotient * r_new;
+		swap(&mut r, &mut r_new);
+
+		//t might go negative here, so we have to do a checked subtract
+		//if it underflows, wrap it around to the other end of the modulo
+		//IE, 3 - 4 mod 5  =  -1 mod 5  =  4
+		let t_subtract = quotient * t_new;
+		t = if t_subtract < t {
+			t - t_subtract
+		} else {
+			n - (t_subtract - t) % n
+		};
+		swap(&mut t, &mut t_new);
+	}
+
+	t
+}
+
+/// return all of the prime factors of n, but omit duplicate prime factors
+pub fn distinct_prime_factors(mut n: u64) -> Vec<u64> {
+	let mut result = Vec::new();
+
+	//handle 2 separately so we dont have to worry about adding 2 vs 1
+	if n % 2 == 0 {
+		while n % 2 == 0 {
+			n /= 2;
+		}
+		result.push(2);
+	}
+
+	let mut divisor = 3;
+	let mut limit = (n as f32).sqrt() as u64 + 1;
+	while divisor < limit {
+		if n % divisor == 0 {
+
+			//remove as many factors as possible from n
+			while n % divisor == 0 {
+				n /= divisor;
+			}
+			result.push(divisor);
+
+			//recalculate the limit to reduce the amount of work we need to do
+			limit = (n as f32).sqrt() as u64 + 1;
+		}
+
+		divisor += 2;
+	}
+
+	result.push(n);
+
+	result
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn test_modular_exponent() {
+		// make sure to test something that would overflow under ordinary circumstances
+		// ie 3 ^ 416788 mod 47
+		let test_list = vec![
+			((2,8,300), 256),
+			((2,9,300), 212),
+			((1,9,300), 1),
+			((3,416788,47), 8),
+		];
+		
+		for (input, expected) in test_list {
+			let (base, exponent, modulo) = input;
+
+			let result = modular_exponent(base, exponent, modulo);
+
+			assert_eq!(result, expected);
+		}
+	}
+
+	#[test]
+	fn test_multiplicative_inverse() {
+		let prime_list = vec![3,5,7,11,13,17,19,23,29];
+		
+		for modulo in prime_list {
+			for i in 2..modulo {
+				let inverse = multiplicative_inverse(i, modulo);
+
+				assert_eq!(i * inverse % modulo, 1);
+			}
+		}
+	}
+
+	#[test]
+	fn test_primitive_root() {
+		let test_list = vec![
+			(3, 2),
+			(7, 3),
+			(11, 2),
+			(13, 2),
+			(47, 5),
+			(7919, 7)
+			];
+		
+		for (input, expected) in test_list {
+			let root = primitive_root(input).unwrap();
+
+			assert_eq!(root, expected);
+		}
+	}
+
+	#[test]
+	fn test_prime_factors() {
+		println!("beginning of test");
+		let test_list = vec![
+			(46, vec![2,23]),
+			];
+		
+		for (input, expected) in test_list {
+			let factors = distinct_prime_factors(input);
+
+			assert_eq!(factors, expected);
+		}
+	}
+}

--- a/src/raders_algorithm.rs
+++ b/src/raders_algorithm.rs
@@ -6,40 +6,46 @@ use butterflies::butterfly_2_single;
 use math_utils;
 
 pub struct RadersAlgorithm<T> {
-	len: usize,
+    len: usize,
 
-	primitive_root: u64,
+    primitive_root: u64,
     root_inverse: u64,
 
-	unity_fft_result: Vec<Complex<T>>,
-	scratch: Vec<Complex<T>>,
+    unity_fft_result: Vec<Complex<T>>,
+    scratch: Vec<Complex<T>>,
 
     inner_fft: InnerFFT<T>,
 }
 
-impl<T> RadersAlgorithm<T> where T: Signed + FromPrimitive + Copy {
+impl<T> RadersAlgorithm<T>
+    where T: Signed + FromPrimitive + Copy
+{
+    pub fn new(len: usize, inverse: bool) -> Self {
 
-	pub fn new(len: usize, inverse: bool) -> Self {
-
-		// we can theoretically just always do n - 1 as the inner FFT size
-		// BUT the code will be much simpler if we can just always call radix 2
-		// so we only use n - 1 if it's a power of two. otherwise we'll pad it out to the next power of two
+        // we can theoretically just always do n - 1 as the inner FFT size
+        // BUT the code will be much simpler if we can just always call radix 2
+        // so we only use n - 1 if it's a power of two
+        // otherwise we'll pad it out to the next power of two
         let inner_fft_size = if (len - 1).is_power_of_two() {
-        	len - 1
+            len - 1
         } else {
-        	(2 * len - 3).next_power_of_two()
+            (2 * len - 3).next_power_of_two()
         };
 
-        //compute the primitive root and its inverse for this size
+        // compute the primitive root and its inverse for this size
         let primitive_root = math_utils::primitive_root(len as u64).unwrap();
         let root_inverse = math_utils::multiplicative_inverse(primitive_root, len as u64);
 
-        //precompute the coefficients to use inside the process method
+        // precompute the coefficients to use inside the process method
         let unity_scale = 1f32 / inner_fft_size as f32;
-        let dir = if inverse { 1 } else { -1 };
+        let dir = if inverse {
+            1
+        } else {
+            -1
+        };
         let mut unity_fft_data: Vec<Complex<T>> = (0..len - 1)
             .map(|i| math_utils::modular_exponent(root_inverse, i as u64, len as u64))
-            .map(|i| { dir as f32 * i as f32 * 2.0 * f32::consts::PI / len as f32})
+            .map(|i| dir as f32 * i as f32 * 2.0 * f32::consts::PI / len as f32)
             .map(|phase| Complex::from_polar(&unity_scale, &phase))
             .map(|c| {
                 Complex {
@@ -49,7 +55,7 @@ impl<T> RadersAlgorithm<T> where T: Signed + FromPrimitive + Copy {
             })
             .collect();
 
-        //pad out the fft input if necessary by repeating the values
+        // pad out the fft input if necessary by repeating the values
         unity_fft_data.reserve(inner_fft_size);
         let mut index = 0;
         while unity_fft_data.len() < inner_fft_size {
@@ -62,8 +68,8 @@ impl<T> RadersAlgorithm<T> where T: Signed + FromPrimitive + Copy {
         inner_fft.process(unity_fft_data.as_mut_slice());
 
         RadersAlgorithm {
-        	len: len,
-        	primitive_root: primitive_root,
+            len: len,
+            primitive_root: primitive_root,
             root_inverse: root_inverse,
             unity_fft_result: unity_fft_data,
             scratch: vec![Zero::zero(); inner_fft_size],
@@ -73,33 +79,35 @@ impl<T> RadersAlgorithm<T> where T: Signed + FromPrimitive + Copy {
 
     /// Runs the FFT on the input `input` buffer, replacing it with the FFT result
     pub fn process(&mut self, input: &mut [Complex<T>]) {
-    	assert!(input.len() == self.len);
+        assert!(input.len() == self.len);
 
         self.setup_inner_fft(input);
 
-    	//use radix 2 to run a FFT on the data now in the scratch space
-    	self.inner_fft.process(self.scratch.as_mut_slice());
+        // use radix 2 to run a FFT on the data now in the scratch space
+        self.inner_fft.process(self.scratch.as_mut_slice());
 
-    	//multiply the result pointwise with the cached unity FFT
-    	for (scratch_item, unity) in self.scratch.iter_mut().zip(self.unity_fft_result.iter()) {
-    		*scratch_item = *scratch_item * unity;
-    	}
+        // multiply the result pointwise with the cached unity FFT
+        for (scratch_item, unity) in self.scratch.iter_mut().zip(self.unity_fft_result.iter()) {
+            *scratch_item = *scratch_item * unity;
+        }
 
-    	//execute the inverse FFT
-    	self.inner_fft.process_inverse(self.scratch.as_mut_slice());
+        // execute the inverse FFT
+        self.inner_fft.process_inverse(self.scratch.as_mut_slice());
 
         // the first output element is equal to the sum of the whole array.
-        //but we need the first input element, so store it before computing the output
+        // but we need the first input element, so store it before computing the output
         let first_input = unsafe { *input.get_unchecked(0) };
-        *unsafe { input.get_unchecked_mut(0) } = input.iter().fold(Zero::zero(), |acc, &x| acc + x);;
 
-        //copy the rest of the output from the scratch space
+        let sum = input.iter().fold(Zero::zero(), |acc, &x| acc + x);
+        *unsafe { input.get_unchecked_mut(0) } = sum;
+
+        // copy the rest of the output from the scratch space
         self.copy_to_output(input, first_input);
     }
 
     fn setup_inner_fft(&mut self, input: &[Complex<T>]) {
-        //it's not just a straight copy from the input to the scratch, we have
-        //to compute the input index based on the scratch index and primitive root
+        // it's not just a straight copy from the input to the scratch, we have
+        // to compute the input index based on the scratch index and primitive root
         let get_input_val = |base: u64, exponent: u64, modulo: u64| {
             let input_index = math_utils::modular_exponent(base, exponent, modulo) as usize;
             unsafe { *input.get_unchecked(input_index) }
@@ -108,38 +116,48 @@ impl<T> RadersAlgorithm<T> where T: Signed + FromPrimitive + Copy {
         // copy the input into the scratch space
         if self.len - 1 == self.scratch.len() {
             for (scratch_index, scratch_element) in self.scratch.iter_mut().enumerate() {
-                *scratch_element =  get_input_val(self.primitive_root, scratch_index as u64, self.len as u64);
+                *scratch_element =
+                    get_input_val(self.primitive_root, scratch_index as u64, self.len as u64);
             }
         } else {
-            //we have to zero-pad the input in a very specific way. input[1]
-            //goes at the beginning of the scratch, and the rest is packed at the end
-            //the rest is zeroes
-            unsafe { *self.scratch.get_unchecked_mut(0) = *input.get_unchecked(1); };
+            // we have to zero-pad the input in a very specific way. input[1]
+            // goes at the beginning of the scratch, and the rest is packed at the end
+            // the rest is zeroes
+            unsafe {
+                *self.scratch.get_unchecked_mut(0) = *input.get_unchecked(1);
+            };
 
-            //zero fill the middle
+            // zero fill the middle
             let zero_end = self.scratch.len() - (self.len - 2);
             zero_fill(&mut self.scratch[1..zero_end]);
 
-            for (scratch_index, scratch_element) in self.scratch[zero_end..].iter_mut().enumerate() {
-                *scratch_element = get_input_val(self.primitive_root, (scratch_index + 1) as u64, self.len as u64);
+            for (scratch_index, scratch_element) in self.scratch[zero_end..]
+                .iter_mut()
+                .enumerate() {
+                *scratch_element = get_input_val(self.primitive_root,
+                                                 (scratch_index + 1) as u64,
+                                                 self.len as u64);
             }
         }
     }
 
     fn copy_to_output(&mut self, output: &mut [Complex<T>], first_element: Complex<T>) {
-        //copy the data back into the input vector, but again it's not just a straight copy
-        for (scratch_index, scratch_element) in self.scratch[..self.len-1].iter().enumerate() {
-            let output_index = math_utils::modular_exponent(self.root_inverse, scratch_index as u64, self.len as u64) as usize;
+        // copy the data back into the input vector, but again it's not just a straight copy
+        for (scratch_index, scratch_element) in self.scratch[..self.len - 1].iter().enumerate() {
+            let output_index =
+                math_utils::modular_exponent(self.root_inverse,
+                                             scratch_index as u64,
+                                             self.len as u64) as usize;
 
-            *unsafe{ output.get_unchecked_mut(output_index) } = first_element + *scratch_element;
+            *unsafe { output.get_unchecked_mut(output_index) } = first_element + *scratch_element;
         }
     }
 }
 
 fn zero_fill<T: Num + Clone>(input: &mut [Complex<T>]) {
-	for element in input.iter_mut() {
-		*element = Zero::zero();
-	}
+    for element in input.iter_mut() {
+        *element = Zero::zero();
+    }
 }
 
 
@@ -160,10 +178,15 @@ struct InnerFFT<T> {
     twiddles: Vec<Complex<T>>,
 }
 
-impl<T> InnerFFT<T> where T: Signed + FromPrimitive + Copy {
-
+impl<T> InnerFFT<T>
+    where T: Signed + FromPrimitive + Copy
+{
     pub fn new(len: usize, inverse: bool) -> Self {
-        let dir = if inverse { 1 } else { -1 };
+        let dir = if inverse {
+            1
+        } else {
+            -1
+        };
 
         InnerFFT {
             twiddles: (0..len)
@@ -187,7 +210,7 @@ impl<T> InnerFFT<T> where T: Signed + FromPrimitive + Copy {
         // the innermost for loop is basically the "butterfly_2" function, except
         // butterfly_2 is designed for a DIT FFT, and we need DIF
         let num_layers = spectrum.len().trailing_zeros() as usize;
-        for layer in 0..num_layers-1 {
+        for layer in 0..num_layers - 1 {
             let num_groups = 1 << layer;
             let group_size = spectrum.len() / num_groups;
             let distance = group_size / 2;
@@ -197,7 +220,10 @@ impl<T> InnerFFT<T> where T: Signed + FromPrimitive + Copy {
                     let twiddle = unsafe { *self.twiddles.get_unchecked(i * num_groups) };
 
                     let second_entry = unsafe { *chunk.get_unchecked(i + distance) };
-                    unsafe { *chunk.get_unchecked_mut(i + distance) = (*chunk.get_unchecked(i) - second_entry) * twiddle };
+                    unsafe {
+                        *chunk.get_unchecked_mut(i + distance) =
+                            (*chunk.get_unchecked(i) - second_entry) * twiddle
+                    };
                     unsafe { *chunk.get_unchecked_mut(i) = *chunk.get_unchecked(i) + second_entry };
                 }
             }
@@ -222,7 +248,7 @@ impl<T> InnerFFT<T> where T: Signed + FromPrimitive + Copy {
         // the innermost for loop is basically the "butterfly_2" step, except
         // we're calling ".conj()" on each twiddle factor before using it
         let num_layers = spectrum.len().trailing_zeros() as usize;
-        for layer in (0..num_layers-1).rev() {
+        for layer in (0..num_layers - 1).rev() {
             let num_groups = 1 << layer;
             let group_size = spectrum.len() / num_groups;
             let distance = group_size / 2;
@@ -232,7 +258,9 @@ impl<T> InnerFFT<T> where T: Signed + FromPrimitive + Copy {
                     let twiddle = unsafe { self.twiddles.get_unchecked(i * num_groups) };
 
                     let twiddled = twiddle.conj() * unsafe { chunk.get_unchecked(i + distance) };
-                    unsafe { *chunk.get_unchecked_mut(i + distance) = *chunk.get_unchecked(i) - twiddled };
+                    unsafe {
+                        *chunk.get_unchecked_mut(i + distance) = *chunk.get_unchecked(i) - twiddled
+                    };
                     unsafe { *chunk.get_unchecked_mut(i) = *chunk.get_unchecked(i) + twiddled };
                 }
             }
@@ -276,13 +304,13 @@ mod test {
 
         let mut result = input.clone();
 
-        //to set up for the inverse FFT, use the correct FFT to get the midpoint, then reorder it
+        // to set up for the inverse FFT, use the correct FFT to get the midpoint, then reorder it
         correct_fft.process(input.as_slice(), result.as_mut_slice());
         reorder(result.as_mut_slice());
 
         fft.process_inverse(result.as_mut_slice());
 
-        //we have to scale by 1/n to get back to the input vector
+        // we have to scale by 1/n to get back to the input vector
         let result_scale = 1f32 / len as f32;
         for element in result.iter_mut() {
             *element = *element * result_scale;

--- a/src/raders_algorithm.rs
+++ b/src/raders_algorithm.rs
@@ -1,21 +1,19 @@
 
-use num::{Complex, Zero, One, Float, FromPrimitive, Signed, Num, Integer, PrimInt};
-use num::traits::cast;
-use num::CheckedSub;
+use num::{Complex, Zero, FromPrimitive, Signed, Num};
 use std::f32;
-use std::mem::swap;
 
-use std::ops::Add;
-use radix4::execute_radix2;
+use radix4::process_radix2_inplace;
 use math_utils;
 
 pub struct RadersAlgorithm<T> {
 	len: usize,
-	primitive_root: usize,
+
+	primitive_root: u64,
+    root_inverse: u64,
+
 	twiddles: Vec<Complex<T>>,
 	unity_fft_result: Vec<Complex<T>>,
 	scratch: Vec<Complex<T>>,
-	inverse: bool,
 }
 
 impl<T> RadersAlgorithm<T> where T: Signed + FromPrimitive + Copy {
@@ -31,24 +29,59 @@ impl<T> RadersAlgorithm<T> where T: Signed + FromPrimitive + Copy {
         	(2 * len - 3).next_power_of_two()
         };
 
-        let dir = if inverse { 1 } else { -1 } as usize;
+        let dir = if inverse { 1 } else { -1 };
+
+        //compute the primitive root and its inverse for this size
+        let primitive_root = math_utils::primitive_root(len as u64).unwrap();
+        let root_inverse = math_utils::multiplicative_inverse(primitive_root, len as u64);
+
+        //compute the twiddles for the inner fft
+        let inner_twiddles: Vec<Complex<T>> = (0..inner_fft_size)
+            .map(|i| dir as f32 * i as f32 * 2.0 * f32::consts::PI / inner_fft_size as f32)
+            .map(|phase| Complex::from_polar(&1.0, &phase))
+            .map(|c| {
+                Complex {
+                    re: FromPrimitive::from_f32(c.re).unwrap(),
+                    im: FromPrimitive::from_f32(c.im).unwrap(),
+                }
+            })
+            .collect();
+
+        let size_float: f32 = FromPrimitive::from_usize(inner_fft_size).unwrap();
+        let length_scale = 1f32 / size_float;
+
+        //precompute the coefficients to use inside the process method
+        let mut unity_fft_data: Vec<Complex<T>> = (0..len - 1)
+            .map(|i| math_utils::modular_exponent(root_inverse, i as u64, len as u64))
+            .map(|i| { dir as f32 * i as f32 * 2.0 * f32::consts::PI / len as f32})
+            .map(|phase| Complex::from_polar(&length_scale, &phase))
+            .map(|c| {
+                Complex {
+                    re: FromPrimitive::from_f32(c.re).unwrap(),
+                    im: FromPrimitive::from_f32(c.im).unwrap(),
+                }
+            })
+            .collect();
+
+        //pad out the fft input if necessary by repeating the values
+        unity_fft_data.reserve(inner_fft_size);
+        let mut index = 0;
+        while unity_fft_data.len() < inner_fft_size {
+            let element = unsafe { *unity_fft_data.get_unchecked(index) };
+            unity_fft_data.push(element);
+            index += 1;
+        }
+
+        //FFT the unity fft data
+        process_radix2_inplace(inner_fft_size, unity_fft_data.as_mut_slice(), 1, inner_twiddles.as_slice());
 
         RadersAlgorithm {
         	len: len,
-        	primitive_root: math_utils::primitive_root(len as u64).unwrap() as usize,
-            twiddles: (0..inner_fft_size)
-                .map(|i| dir as f32 * i as f32 * 2.0 * f32::consts::PI / len as f32)
-                .map(|phase| Complex::from_polar(&1.0, &phase))
-                .map(|c| {
-                    Complex {
-                        re: FromPrimitive::from_f32(c.re).unwrap(),
-                        im: FromPrimitive::from_f32(c.im).unwrap(),
-                    }
-                })
-                .collect(),
-            unity_fft_result: Vec::new(),
+        	primitive_root: primitive_root,
+            root_inverse: root_inverse,
+            unity_fft_result: unity_fft_data,
+            twiddles: inner_twiddles,
             scratch: vec![Zero::zero(); inner_fft_size],
-            inverse: inverse,
         }
     }
 
@@ -56,33 +89,10 @@ impl<T> RadersAlgorithm<T> where T: Signed + FromPrimitive + Copy {
     pub fn process(&mut self, input: &mut [Complex<T>], stride: usize) {
     	assert!(input.len() == self.len);
 
-    	// the first output element is equal to the sum of the others. but we need the first input element, so sore it before computing the output
-    	let first_input = unsafe { *input.get_unchecked(0) };
-    	for i in 1..self.len {
-    		unsafe { *input.get_unchecked_mut(0) = input.get_unchecked(0) + input.get_unchecked(i * stride); }
-    	}
+        self.setup_inner_fft(input, stride);
 
-    	// copy the input into the scratch space
-    	if self.len - 1 == self.scratch.len() {
-    		//ignore input[0] because we already computed it
-    		unsafe { copy_data(&input[stride..], self.scratch.as_mut_slice(), self.len - 1, stride, 1) }
-    	} else {
-    		//we have to zero-pad the input in a very specific way. input[1] goes at the beginning of the scratch, and the rest is packed at the end
-    		//the rest is zeroes
-    		unsafe { *self.scratch.get_unchecked_mut(0) = *input.get_unchecked(stride); }
-
-    		//zero fill the middle
-    		let zero_end = self.scratch.len() - (self.len - 2);
-    		zero_fill(&mut self.scratch[1..zero_end]);
-
-    		//fill in the rest wih the rest of the input array
-    		unsafe { copy_data(&input[2*stride..], &mut self.scratch[zero_end..], self.len - 2, stride, 1) }
-    	}
-
-    	//use radix 2 to run a FFT on the data now in the scratch space. but explicitly avoid the preparation step!
-    	//all the preparation would do is reorder the inputs. but we're about to do an inverse FFT
-    	//and said inverse FFT will do our job of reordering for us
-    	execute_radix2(self.scratch.len(), self.scratch.as_mut_slice(), 1, self.twiddles.as_slice());
+    	//use radix 2 to run a FFT on the data now in the scratch space
+    	process_radix2_inplace(self.scratch.len(), self.scratch.as_mut_slice(), 1, self.twiddles.as_slice());
 
     	//multiply the result pointwise with the cached unity FFT
     	for (scratch_item, unity) in self.scratch.iter_mut().zip(self.unity_fft_result.iter()) {
@@ -93,12 +103,55 @@ impl<T> RadersAlgorithm<T> where T: Signed + FromPrimitive + Copy {
     	self.conjugate_twiddles();
 
     	//execute the inverse FFT
-    	execute_radix2(self.scratch.len(), self.scratch.as_mut_slice(), 1, self.twiddles.as_slice());
+    	process_radix2_inplace(self.scratch.len(), self.scratch.as_mut_slice(), 1, self.twiddles.as_slice());
 
     	//make sure we'll be ready for the next call by undoing the twiddle conjugation
     	self.conjugate_twiddles();
 
-    	unsafe { copy_data(&self.scratch[..self.len - 1], &mut input[stride..], self.len - 1, 1, stride) }
+        // the first output element is equal to the sum of the others. but we need the first input element, so store it before computing the output
+        let first_input = unsafe { *input.get_unchecked(0) };
+        for i in 1..self.len {
+            unsafe { *input.get_unchecked_mut(0) = input.get_unchecked(0) + input.get_unchecked(i * stride); }
+        }
+
+        //copy the data back into the input vector, but again it's not just a straight copy
+    	for scratch_index in 0..self.len-1 {
+            let output_index = math_utils::modular_exponent(self.root_inverse, scratch_index as u64, self.len as u64) as usize;
+
+            unsafe {
+                *input.get_unchecked_mut (stride * output_index) = 
+                first_input + *self.scratch.get_unchecked_mut(scratch_index);
+            }
+        }
+    }
+
+    fn setup_inner_fft(&mut self, input: &[Complex<T>], stride: usize) {
+        //it's not just a straight copy from the input to the scratch, we have
+        //to compute the input index based on the scratch index and primitive root
+        let get_input_val = |base: u64, exponent: u64, modulo: u64| {
+            let input_index = math_utils::modular_exponent(base, exponent, modulo) as usize;
+            unsafe { *input.get_unchecked(stride * input_index) }
+        };
+
+        // copy the input into the scratch space
+        if self.len - 1 == self.scratch.len() {
+            for scratch_index in 0..self.scratch.len() {
+                unsafe { *self.scratch.get_unchecked_mut(scratch_index) = get_input_val(self.primitive_root, scratch_index as u64, self.len as u64) };
+            }
+        } else {
+            //we have to zero-pad the input in a very specific way. input[1] goes at the beginning of the scratch, and the rest is packed at the end
+            //the rest is zeroes
+            unsafe { *self.scratch.get_unchecked_mut(0) = *input.get_unchecked(stride); };
+
+            //zero fill the middle
+            let zero_end = self.scratch.len() - (self.len - 2);
+            zero_fill(&mut self.scratch[1..zero_end]);
+
+            for scratch_index in 1..self.len-1 {
+                unsafe { *self.scratch.get_unchecked_mut(scratch_index + zero_end - 1)
+                    = get_input_val(self.primitive_root, scratch_index as u64, self.len as u64) };
+            }
+        }
     }
 
     fn conjugate_twiddles(&mut self) {
@@ -111,11 +164,5 @@ impl<T> RadersAlgorithm<T> where T: Signed + FromPrimitive + Copy {
 fn zero_fill<T: Num + Clone>(input: &mut [Complex<T>]) {
 	for element in input.iter_mut() {
 		*element = Zero::zero();
-	}
-}
-
-unsafe fn copy_data<T: Copy>(source: &[T], dest: &mut [T], count: usize, source_stride: usize, dest_stride: usize) {
-	for i in 0..count {
-		*dest.get_unchecked_mut(i * dest_stride) = *source.get_unchecked(i * source_stride);
 	}
 }

--- a/src/raders_algorithm.rs
+++ b/src/raders_algorithm.rs
@@ -1,0 +1,121 @@
+
+use num::{Complex, Zero, One, Float, FromPrimitive, Signed, Num, Integer, PrimInt};
+use num::traits::cast;
+use num::CheckedSub;
+use std::f32;
+use std::mem::swap;
+
+use std::ops::Add;
+use radix4::execute_radix2;
+use math_utils;
+
+pub struct RadersAlgorithm<T> {
+	len: usize,
+	primitive_root: usize,
+	twiddles: Vec<Complex<T>>,
+	unity_fft_result: Vec<Complex<T>>,
+	scratch: Vec<Complex<T>>,
+	inverse: bool,
+}
+
+impl<T> RadersAlgorithm<T> where T: Signed + FromPrimitive + Copy {
+
+	pub fn new(len: usize, inverse: bool) -> Self {
+
+		// we can theoretically just always do n - 1 as the inner FFT size
+		// BUT the code will be much simpler if we can just always call radix 4 -- because it doesn't need any extra scratch space
+		// so we only use n - 1 if it's a power of two. otherwise we'll pad it out to the next power of two
+        let inner_fft_size = if (len - 1).is_power_of_two() {
+        	len - 1
+        } else {
+        	(2 * len - 3).next_power_of_two()
+        };
+
+        let dir = if inverse { 1 } else { -1 } as usize;
+
+        RadersAlgorithm {
+        	len: len,
+        	primitive_root: math_utils::primitive_root(len as u64).unwrap() as usize,
+            twiddles: (0..inner_fft_size)
+                .map(|i| dir as f32 * i as f32 * 2.0 * f32::consts::PI / len as f32)
+                .map(|phase| Complex::from_polar(&1.0, &phase))
+                .map(|c| {
+                    Complex {
+                        re: FromPrimitive::from_f32(c.re).unwrap(),
+                        im: FromPrimitive::from_f32(c.im).unwrap(),
+                    }
+                })
+                .collect(),
+            unity_fft_result: Vec::new(),
+            scratch: vec![Zero::zero(); inner_fft_size],
+            inverse: inverse,
+        }
+    }
+
+    /// Runs the FFT on the input `input` buffer, replacing it with the FFT result
+    pub fn process(&mut self, input: &mut [Complex<T>], stride: usize) {
+    	assert!(input.len() == self.len);
+
+    	// the first output element is equal to the sum of the others. but we need the first input element, so sore it before computing the output
+    	let first_input = unsafe { *input.get_unchecked(0) };
+    	for i in 1..self.len {
+    		unsafe { *input.get_unchecked_mut(0) = input.get_unchecked(0) + input.get_unchecked(i * stride); }
+    	}
+
+    	// copy the input into the scratch space
+    	if self.len - 1 == self.scratch.len() {
+    		//ignore input[0] because we already computed it
+    		unsafe { copy_data(&input[stride..], self.scratch.as_mut_slice(), self.len - 1, stride, 1) }
+    	} else {
+    		//we have to zero-pad the input in a very specific way. input[1] goes at the beginning of the scratch, and the rest is packed at the end
+    		//the rest is zeroes
+    		unsafe { *self.scratch.get_unchecked_mut(0) = *input.get_unchecked(stride); }
+
+    		//zero fill the middle
+    		let zero_end = self.scratch.len() - (self.len - 2);
+    		zero_fill(&mut self.scratch[1..zero_end]);
+
+    		//fill in the rest wih the rest of the input array
+    		unsafe { copy_data(&input[2*stride..], &mut self.scratch[zero_end..], self.len - 2, stride, 1) }
+    	}
+
+    	//use radix 2 to run a FFT on the data now in the scratch space. but explicitly avoid the preparation step!
+    	//all the preparation would do is reorder the inputs. but we're about to do an inverse FFT
+    	//and said inverse FFT will do our job of reordering for us
+    	execute_radix2(self.scratch.len(), self.scratch.as_mut_slice(), 1, self.twiddles.as_slice());
+
+    	//multiply the result pointwise with the cached unity FFT
+    	for (scratch_item, unity) in self.scratch.iter_mut().zip(self.unity_fft_result.iter()) {
+    		*scratch_item = *scratch_item * unity;
+    	}
+
+    	//prepare for the inverse FFT by conjugating all our twiddle factors
+    	self.conjugate_twiddles();
+
+    	//execute the inverse FFT
+    	execute_radix2(self.scratch.len(), self.scratch.as_mut_slice(), 1, self.twiddles.as_slice());
+
+    	//make sure we'll be ready for the next call by undoing the twiddle conjugation
+    	self.conjugate_twiddles();
+
+    	unsafe { copy_data(&self.scratch[..self.len - 1], &mut input[stride..], self.len - 1, 1, stride) }
+    }
+
+    fn conjugate_twiddles(&mut self) {
+    	for item in &mut self.twiddles {
+    		*item = item.conj();
+    	}
+    }
+}
+
+fn zero_fill<T: Num + Clone>(input: &mut [Complex<T>]) {
+	for element in input.iter_mut() {
+		*element = Zero::zero();
+	}
+}
+
+unsafe fn copy_data<T: Copy>(source: &[T], dest: &mut [T], count: usize, source_stride: usize, dest_stride: usize) {
+	for i in 0..count {
+		*dest.get_unchecked_mut(i * dest_stride) = *source.get_unchecked(i * source_stride);
+	}
+}


### PR DESCRIPTION
In a nutshell, rader's algorithm rearranges the input based on a number theory concept called the "primitive root", then pads the rearranged input out to the next power of two. It then runs 2 FFTs on that padded data, then rearranges the result back into the output.

Since we're doing so much padding and running multiple inner FFTs, there's pretty significant overhead. compared to the other two algorithms at similar sizes. It's still O(nlogn), so for large inputs it's worth the overhead. But it has a pretty high constant factor, so to speak, so for small sizes the O(n^2) algorithm may still be faster. Based on benchmarking, this implementation of rader's algorithm is faster than letting the cooley_tukey function handle it when N > 100, so it only uses this algorithm if N > 100.
