### PR TITLE
Ergonomics improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ keywords = ["fft", "dft", "fourier", "signal"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-num = "*"
+num-complex = "0.1.36"
+num-traits = "0.1.37"
 
 [dev-dependencies]
 rand = "*"

--- a/benches/rustfft.rs
+++ b/benches/rustfft.rs
@@ -1,10 +1,9 @@
 #![feature(test)]
 extern crate test;
-extern crate num;
 extern crate rustfft;
 
 use test::Bencher;
-use num::Complex;
+use rustfft::num_complex::Complex;
 
 /// Times just the FFT execution (not allocation and pre-calculation)
 /// for a given length

--- a/benches/rustfft.rs
+++ b/benches/rustfft.rs
@@ -9,7 +9,7 @@ use rustfft::num_complex::Complex;
 /// for a given length
 fn bench_fft(b: &mut Bencher, len: usize) {
 
-    let mut planner = rustfft::Planner::new(false);
+    let mut planner = rustfft::FFTplanner::new(false);
     let fft = planner.plan_fft(len);
 
     let mut signal = vec![Complex{re: 0_f32, im: 0_f32}; len];

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -1,4 +1,6 @@
-use num::{Complex, FromPrimitive, Zero};
+use num_complex::Complex;
+use num_traits::{FromPrimitive, Zero};
+
 use common::{FFTnum, verify_length, verify_length_divisible};
 
 use twiddles;
@@ -696,7 +698,7 @@ mod unit_tests {
 	use super::*;
 	use test_utils::{random_signal, compare_vectors, check_fft_algorithm};
 	use algorithm::DFT;
-	use num::Zero;
+	use num_traits::Zero;
 
 	#[test]
 	fn test_butterfly2() {

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -4,10 +4,10 @@ use num_traits::{FromPrimitive, Zero};
 use common::{FFTnum, verify_length, verify_length_divisible};
 
 use twiddles;
-use ::{Length, FFT};
+use ::{Length, IsInverse, FFT};
 
 
-pub trait FFTButterfly<T: FFTnum>: Length {
+pub trait FFTButterfly<T: FFTnum>: Length + IsInverse {
     unsafe fn process_inplace(&self, buffer: &mut [Complex<T>]);
     unsafe fn process_multi_inplace(&self, buffer: &mut [Complex<T>]);
 }
@@ -24,8 +24,17 @@ unsafe fn swap_unchecked<T: Copy>(buffer: &mut [T], a: usize, b: usize) {
 
 
 
-pub struct Butterfly2;
+pub struct Butterfly2 {
+    inverse: bool,
+}
 impl Butterfly2 {
+    #[inline(always)]
+    pub fn new(inverse: bool) -> Self {
+        Butterfly2 {
+            inverse: inverse,
+        }
+    }
+
     #[inline(always)]
     unsafe fn perform_fft_direct<T: FFTnum>(&self, left: &mut Complex<T>, right: &mut Complex<T>) {
         let temp = *left + *right;
@@ -69,31 +78,40 @@ impl Length for Butterfly2 {
         2
     }
 }
+impl IsInverse for Butterfly2 {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inverse
+    }
+}
 
 
 
 pub struct Butterfly3<T> {
 	pub twiddle: Complex<T>,
+    inverse: bool,
 }
 impl<T: FFTnum> Butterfly3<T> {
 	#[inline(always)]
     pub fn new(inverse: bool) -> Self {
         Butterfly3 {
-            twiddle: twiddles::single_twiddle(1, 3, inverse)
+            twiddle: twiddles::single_twiddle(1, 3, inverse),
+            inverse: inverse,
         }
     }
 
     #[inline(always)]
     pub fn inverse_of(fft: &Butterfly3<T>) -> Self {
         Butterfly3 {
-            twiddle: fft.twiddle.conj()
+            twiddle: fft.twiddle.conj(),
+            inverse: !fft.inverse,
         }
     }
 }
 impl<T: FFTnum> FFTButterfly<T> for Butterfly3<T> {
     #[inline(always)]
     unsafe fn process_inplace(&self, buffer: &mut [Complex<T>]) {
-        let butterfly2 = Butterfly2{};
+        let butterfly2 = Butterfly2::new(self.inverse);
 
         butterfly2.process_inplace(&mut buffer[1..]);
         let temp = *buffer.get_unchecked(0);
@@ -132,6 +150,13 @@ impl<T> Length for Butterfly3<T> {
         3
     }
 }
+impl<T> IsInverse for Butterfly3<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inverse
+    }
+}
+
 
 
 
@@ -149,7 +174,7 @@ impl Butterfly4
 impl<T: FFTnum> FFTButterfly<T> for Butterfly4 {
     #[inline(always)]
     unsafe fn process_inplace(&self, buffer: &mut [Complex<T>]) {
-        let butterfly2 = Butterfly2{};
+        let butterfly2 = Butterfly2::new(self.inverse);
 
         //we're going to hardcode a step of mixed radix
         //aka we're going to do the six step algorithm
@@ -202,6 +227,13 @@ impl Length for Butterfly4 {
         4
     }
 }
+impl IsInverse for Butterfly4 {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inverse
+    }
+}
+
 
 
 
@@ -289,6 +321,12 @@ impl<T> Length for Butterfly5<T> {
         5
     }
 }
+impl<T> IsInverse for Butterfly5<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inverse
+    }
+}
 
 
 
@@ -333,7 +371,7 @@ impl<T: FFTnum> FFTButterfly<T> for Butterfly6<T> {
         // step 4: SKIPPED because the next FFTs will be non-contiguous
 
         // step 5: row FFTs
-        let butterfly2 = Butterfly2{};
+        let butterfly2 = Butterfly2::new(self.butterfly3.is_inverse());
         butterfly2.perform_fft_direct(&mut scratch_a[0], &mut scratch_b[0]);
         butterfly2.perform_fft_direct(&mut scratch_a[1], &mut scratch_b[1]);
         butterfly2.perform_fft_direct(&mut scratch_a[2], &mut scratch_b[2]);
@@ -373,6 +411,12 @@ impl<T> Length for Butterfly6<T> {
     #[inline(always)]
     fn len(&self) -> usize {
         6
+    }
+}
+impl<T> IsInverse for Butterfly6<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.butterfly3.is_inverse()
     }
 }
 
@@ -471,6 +515,12 @@ impl<T> Length for Butterfly7<T> {
         7
     }
 }
+impl<T> IsInverse for Butterfly7<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inner_fft.is_inverse()
+    }
+}
 
 
 
@@ -504,7 +554,7 @@ impl<T: FFTnum> Butterfly8<T>
 impl<T: FFTnum> FFTButterfly<T> for Butterfly8<T> {
     #[inline(always)]
     unsafe fn process_inplace(&self, buffer: &mut [Complex<T>]) {
-        let butterfly2 = Butterfly2{};
+        let butterfly2 = Butterfly2::new(self.inverse);
         let butterfly4 = Butterfly4::new(self.inverse);
 
         //we're going to hardcode a step of mixed radix
@@ -578,6 +628,12 @@ impl<T> Length for Butterfly8<T> {
     #[inline(always)]
     fn len(&self) -> usize {
         8
+    }
+}
+impl<T> IsInverse for Butterfly8<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inverse
     }
 }
 
@@ -690,6 +746,12 @@ impl<T> Length for Butterfly16<T> {
         16
     }
 }
+impl<T> IsInverse for Butterfly16<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inverse
+    }
+}
 
 
 
@@ -700,21 +762,8 @@ mod unit_tests {
 	use algorithm::DFT;
 	use num_traits::Zero;
 
-	#[test]
-	fn test_butterfly2() {
-        let butterfly = Butterfly2{};
-
-        check_fft_algorithm(&butterfly, 2, false);
-        check_fft_algorithm(&butterfly, 2, true);
-
-        check_butterfly(&butterfly, 2, false);
-        check_butterfly(&butterfly, 2, true);
-    }
-
-
-    //the tests for all butterflies except 2 will be identical except for the identifiers used and size
+    //the tests for all butterflies will be identical except for the identifiers used and size
     //so it's ideal for a macro
-    //butterfly 2 is different because it's the only one that doesn't care about forwards vs inverse
     macro_rules! test_butterfly_func {
         ($test_name:ident, $struct_name:ident, $size:expr) => (
             #[test]
@@ -731,6 +780,7 @@ mod unit_tests {
             }
         )
     }
+    test_butterfly_func!(test_butterfly2, Butterfly2, 2);
     test_butterfly_func!(test_butterfly3, Butterfly3, 3);
     test_butterfly_func!(test_butterfly4, Butterfly4, 4);
     test_butterfly_func!(test_butterfly5, Butterfly5, 5);
@@ -742,6 +792,7 @@ mod unit_tests {
 
     fn check_butterfly(butterfly: &FFTButterfly<f32>, size: usize, inverse: bool) {
         assert_eq!(butterfly.len(), size, "Butterfly algorithm reported wrong size");
+        assert_eq!(butterfly.is_inverse(), inverse, "Butterfly algorithm reported wrong inverse value");
 
         let n = 5;
 

--- a/src/algorithm/dft.rs
+++ b/src/algorithm/dft.rs
@@ -1,4 +1,6 @@
-use num::{Complex, Zero};
+use num_complex::Complex;
+use num_traits::Zero;
+
 use common::{FFTnum, verify_length, verify_length_divisible};
 
 use ::{Length, FFT};
@@ -62,7 +64,8 @@ mod unit_tests {
     use super::*;
     use std::f32;
     use test_utils::{random_signal, compare_vectors};
-    use num::{Complex, Zero};
+    use num_complex::Complex;
+    use num_traits::Zero;
 
     fn dft(signal: &[Complex<f32>], spectrum: &mut [Complex<f32>]) {
         for (k, spec_bin) in spectrum.iter_mut().enumerate() {

--- a/src/algorithm/dft.rs
+++ b/src/algorithm/dft.rs
@@ -3,17 +3,19 @@ use num_traits::Zero;
 
 use common::{FFTnum, verify_length, verify_length_divisible};
 
-use ::{Length, FFT};
+use ::{Length, IsInverse, FFT};
 use twiddles;
 
 pub struct DFT<T> {
     twiddles: Vec<Complex<T>>,
+    inverse: bool,
 }
 
 impl<T: FFTnum> DFT<T> {
     pub fn new(len: usize, inverse: bool) -> Self {
         DFT {
             twiddles: twiddles::generate_twiddle_factors(len, inverse),
+            inverse: inverse
         }
     }
 
@@ -56,6 +58,12 @@ impl<T> Length for DFT<T> {
     #[inline(always)]
     fn len(&self) -> usize {
         self.twiddles.len()
+    }
+}
+impl<T> IsInverse for DFT<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inverse
     }
 }
 

--- a/src/algorithm/good_thomas_algorithm.rs
+++ b/src/algorithm/good_thomas_algorithm.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use num::Complex;
+use num_complex::Complex;
 use common::{FFTnum, verify_length, verify_length_divisible};
 
 use math_utils;

--- a/src/algorithm/good_thomas_algorithm.rs
+++ b/src/algorithm/good_thomas_algorithm.rs
@@ -6,7 +6,7 @@ use common::{FFTnum, verify_length, verify_length_divisible};
 use math_utils;
 use array_utils;
 
-use ::{Length, FFT};
+use ::{Length, IsInverse, FFT};
 
 pub struct GoodThomasAlgorithm<T> {
     width: usize,
@@ -19,11 +19,18 @@ pub struct GoodThomasAlgorithm<T> {
 
     input_map: Box<[usize]>,
     output_map: Box<[usize]>,
+
+    inverse: bool,
 }
 
 impl<T: FFTnum> GoodThomasAlgorithm<T> {
     #[allow(dead_code)]
     pub fn new(n1_fft: Rc<FFT<T>>, n2_fft: Rc<FFT<T>>) -> Self {
+
+        assert_eq!(
+            n1_fft.is_inverse(), n2_fft.is_inverse(), 
+            "n1_fft and n2_fft must both be inverse, or neither. got n1 inverse={}, n2 inverse={}",
+            n1_fft.is_inverse(), n2_fft.is_inverse());
 
         let n1 = n1_fft.len();
         let n2 = n2_fft.len();
@@ -63,6 +70,8 @@ impl<T: FFTnum> GoodThomasAlgorithm<T> {
                 .collect();
 
         GoodThomasAlgorithm {
+            inverse: n1_fft.is_inverse(),
+
             width: n1,
             width_size_fft: n1_fft,
 
@@ -115,6 +124,12 @@ impl<T> Length for GoodThomasAlgorithm<T> {
     #[inline(always)]
     fn len(&self) -> usize {
         self.input_map.len()
+    }
+}
+impl<T> IsInverse for GoodThomasAlgorithm<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inverse
     }
 }
 

--- a/src/algorithm/mixed_radix.rs
+++ b/src/algorithm/mixed_radix.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use num::Complex;
+use num_complex::Complex;
 
 use common::{FFTnum, verify_length, verify_length_divisible};
 

--- a/src/algorithm/mixed_radix.rs
+++ b/src/algorithm/mixed_radix.rs
@@ -4,7 +4,7 @@ use num_complex::Complex;
 
 use common::{FFTnum, verify_length, verify_length_divisible};
 
-use ::{Length, FFT};
+use ::{Length, IsInverse, FFT};
 use algorithm::butterflies::FFTButterfly;
 use array_utils;
 use twiddles;
@@ -17,10 +17,17 @@ pub struct MixedRadix<T> {
     height_size_fft: Rc<FFT<T>>,
 
     twiddles: Box<[Complex<T>]>,
+    inverse: bool,
 }
 
 impl<T: FFTnum> MixedRadix<T> {
-    pub fn new(width_fft: Rc<FFT<T>>, height_fft: Rc<FFT<T>>, inverse: bool) -> Self {
+    pub fn new(width_fft: Rc<FFT<T>>, height_fft: Rc<FFT<T>>) -> Self {
+        assert_eq!(
+            width_fft.is_inverse(), height_fft.is_inverse(), 
+            "width_fft and height_fft must both be inverse, or neither. got width inverse={}, height inverse={}",
+            width_fft.is_inverse(), height_fft.is_inverse());
+
+        let inverse = width_fft.is_inverse();
 
         let width = width_fft.len();
         let height = height_fft.len();
@@ -42,6 +49,7 @@ impl<T: FFTnum> MixedRadix<T> {
             height_size_fft: height_fft,
 
             twiddles: twiddles.into_boxed_slice(),
+            inverse: inverse,
         }
     }
 
@@ -90,6 +98,13 @@ impl<T> Length for MixedRadix<T> {
         self.twiddles.len()
     }
 }
+impl<T> IsInverse for MixedRadix<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inverse
+    }
+}
+
 
 
 
@@ -103,10 +118,18 @@ pub struct MixedRadixDoubleButterfly<T> {
     height_size_fft: Rc<FFTButterfly<T>>,
 
     twiddles: Box<[Complex<T>]>,
+    inverse: bool,
 }
 
 impl<T: FFTnum> MixedRadixDoubleButterfly<T> {
-    pub fn new(width_fft: Rc<FFTButterfly<T>>, height_fft: Rc<FFTButterfly<T>>, inverse: bool) -> Self {
+    pub fn new(width_fft: Rc<FFTButterfly<T>>, height_fft: Rc<FFTButterfly<T>>) -> Self {
+        assert_eq!(
+            width_fft.is_inverse(), height_fft.is_inverse(), 
+            "width_fft and height_fft must both be inverse, or neither. got width inverse={}, height inverse={}",
+            width_fft.is_inverse(), height_fft.is_inverse());
+
+        let inverse = width_fft.is_inverse();
+
         let width = width_fft.len();
         let height = height_fft.len();
 
@@ -127,6 +150,7 @@ impl<T: FFTnum> MixedRadixDoubleButterfly<T> {
             height_size_fft: height_fft,
 
             twiddles: twiddles.into_boxed_slice(),
+            inverse: inverse
         }
     }
 
@@ -176,6 +200,13 @@ impl<T> Length for MixedRadixDoubleButterfly<T> {
         self.twiddles.len()
     }
 }
+impl<T> IsInverse for MixedRadixDoubleButterfly<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inverse
+    }
+}
+
 
 
 
@@ -213,7 +244,7 @@ mod unit_tests {
         let width_fft = Rc::new(DFT::new(width, inverse)) as Rc<FFT<f32>>;
         let height_fft = Rc::new(DFT::new(height, inverse)) as Rc<FFT<f32>>;
 
-        let fft = MixedRadix::new(width_fft, height_fft, inverse);
+        let fft = MixedRadix::new(width_fft, height_fft);
 
         check_fft_algorithm(&fft, width * height, inverse);
     }
@@ -222,14 +253,14 @@ mod unit_tests {
         let width_fft = make_butterfly(width, inverse);
         let height_fft = make_butterfly(height, inverse);
 
-        let fft = MixedRadixDoubleButterfly::new(width_fft, height_fft, inverse);
+        let fft = MixedRadixDoubleButterfly::new(width_fft, height_fft);
 
         check_fft_algorithm(&fft, width * height, inverse);
     }
 
     fn make_butterfly(len: usize, inverse: bool) -> Rc<FFTButterfly<f32>> {
         match len {
-            2 => Rc::new(butterflies::Butterfly2 {}),
+            2 => Rc::new(butterflies::Butterfly2::new(inverse)),
             3 => Rc::new(butterflies::Butterfly3::new(inverse)),
             4 => Rc::new(butterflies::Butterfly4::new(inverse)),
             5 => Rc::new(butterflies::Butterfly5::new(inverse)),

--- a/src/algorithm/raders_algorithm.rs
+++ b/src/algorithm/raders_algorithm.rs
@@ -7,7 +7,7 @@ use common::{FFTnum, verify_length, verify_length_divisible};
 
 use math_utils;
 use twiddles;
-use ::{Length, FFT};
+use ::{Length, IsInverse, FFT};
 
 pub struct RadersAlgorithm<T> {
     inner_fft: Rc<FFT<T>>,
@@ -18,7 +18,7 @@ pub struct RadersAlgorithm<T> {
 }
 
 impl<T: FFTnum> RadersAlgorithm<T> {
-    pub fn new(len: usize, inner_fft: Rc<FFT<T>>, inverse: bool) -> Self {
+    pub fn new(len: usize, inner_fft: Rc<FFT<T>>) -> Self {
         assert_eq!(len - 1, inner_fft.len(), "For raders algorithm, inner_fft.len() must be self.len() - 1. Expected {}, got {}", len - 1, inner_fft.len());
 
         let inner_fft_len = len - 1;
@@ -31,7 +31,7 @@ impl<T: FFTnum> RadersAlgorithm<T> {
         let unity_scale: T = FromPrimitive::from_f64(1f64 / inner_fft_len as f64).unwrap();
         let mut inner_fft_input: Vec<Complex<T>> = (0..inner_fft_len)
             .map(|i| math_utils::modular_exponent(root_inverse, i as u64, len as u64) as usize)
-            .map(|i| twiddles::single_twiddle(i, len, inverse))
+            .map(|i| twiddles::single_twiddle(i, len, inner_fft.is_inverse()))
             .map(|c| c * unity_scale)
             .collect();
 
@@ -118,6 +118,12 @@ impl<T> Length for RadersAlgorithm<T> {
         self.inner_fft_data.len() + 1
     }
 }
+impl<T> IsInverse for RadersAlgorithm<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inner_fft.is_inverse()
+    }
+}
 
 #[cfg(test)]
 mod unit_tests {
@@ -136,7 +142,7 @@ mod unit_tests {
 
     fn test_raders_with_length(len: usize, inverse: bool) {
         let inner_fft = Rc::new(DFT::new(len - 1, inverse));
-        let fft = RadersAlgorithm::new(len, inner_fft, inverse);
+        let fft = RadersAlgorithm::new(len, inner_fft);
 
         check_fft_algorithm(&fft, len, inverse);
     }

--- a/src/algorithm/raders_algorithm.rs
+++ b/src/algorithm/raders_algorithm.rs
@@ -1,6 +1,8 @@
 use std::rc::Rc;
 
-use num::{Complex, Zero, FromPrimitive};
+use num_complex::Complex;
+use num_traits::{FromPrimitive, Zero};
+
 use common::{FFTnum, verify_length, verify_length_divisible};
 
 use math_utils;

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -4,7 +4,7 @@ use num_traits::Zero;
 use common::{FFTnum, verify_length, verify_length_divisible};
 
 use algorithm::butterflies::{Butterfly2, Butterfly4, FFTButterfly};
-use ::{Length, FFT};
+use ::{Length, IsInverse, FFT};
 use twiddles;
 
 pub struct Radix4<T> {
@@ -28,7 +28,7 @@ impl<T: FFTnum> Radix4<T> {
         // perform the butterflies. the butterfly size depends on the input size
         let num_bits = signal.len().trailing_zeros();
         let mut current_size = if num_bits % 2 > 0 {
-            let inner_fft = Butterfly2{};
+            let inner_fft = Butterfly2::new(self.inverse);
             unsafe { inner_fft.process_multi_inplace(spectrum) };
 
             // for the cross-ffts we want to to start off with a size of 8 (2 * 4)
@@ -79,6 +79,15 @@ impl<T> Length for Radix4<T> {
         self.twiddles.len()
     }
 }
+impl<T> IsInverse for Radix4<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inverse
+    }
+}
+
+
+
 // after testing an iterative bit reversal algorithm, this recursive algorithm
 // was almost an order of magnitude faster at setting up
 fn prepare_radix4<T: FFTnum>(size: usize,

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -1,4 +1,6 @@
-use num::{Complex, Zero};
+use num_complex::Complex;
+use num_traits::Zero;
+
 use common::{FFTnum, verify_length, verify_length_divisible};
 
 use algorithm::butterflies::{Butterfly2, Butterfly4, FFTButterfly};

--- a/src/array_utils.rs
+++ b/src/array_utils.rs
@@ -111,7 +111,8 @@ pub unsafe fn transpose_small<T: Copy>(width: usize, height: usize, input: &[T],
 mod unit_tests {
     use super::*;
     use test_utils::random_signal;
-    use num::{Complex, Zero};
+    use num_complex::Complex;
+    use num_traits::Zero;
 
     #[test]
     fn test_transpose() {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,6 @@
 use num_traits::{FromPrimitive, Signed};
-use std::fmt::Debug;
 
-pub trait FFTnum: Copy + FromPrimitive + Signed + Debug + 'static {}
+pub trait FFTnum: Copy + FromPrimitive + Signed + 'static {}
 
 impl FFTnum for f32 {}
 impl FFTnum for f64 {}

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,4 @@
-use num::{FromPrimitive, Signed};
+use num_traits::{FromPrimitive, Signed};
 
 pub trait FFTnum: Copy + FromPrimitive + Signed + 'static {}
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,7 @@
 use num_traits::{FromPrimitive, Signed};
+use std::fmt::Debug;
 
-pub trait FFTnum: Copy + FromPrimitive + Signed + 'static {}
+pub trait FFTnum: Copy + FromPrimitive + Signed + Debug + 'static {}
 
 impl FFTnum for f32 {}
 impl FFTnum for f64 {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod common;
 
 use num_complex::Complex;
 
-pub use plan::Planner;
+pub use plan::FFTplanner;
 pub use common::FFTnum;
 
 /// A trait that allows FFT algorithms to report their expected input/output size

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(all(feature = "bench", test), feature(test))]
 
-extern crate num;
+pub extern crate num_complex;
+pub extern crate num_traits;
 
 pub mod algorithm;
 mod math_utils;
@@ -9,7 +10,7 @@ mod plan;
 mod twiddles;
 mod common;
 
-use num::Complex;
+use num_complex::Complex;
 
 pub use plan::Planner;
 pub use common::FFTnum;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,14 @@ pub trait Length {
     fn len(&self) -> usize;
 }
 
+/// A trait that allows FFT algorithms to report whether they compute forward FFTs or inverse FFTs
+pub trait IsInverse {
+    /// true if this instance computes inverse FFTs, false otherwise
+    fn is_inverse(&self) -> bool;
+}
+
 /// An umbrella trait for all available FFT algorithms
-pub trait FFT<T: FFTnum>: Length {
+pub trait FFT<T: FFTnum>: Length + IsInverse {
     /// Performs an FFT on the `input` buffer, places the result in the `output` buffer.
     /// Uses the `input` buffer as scratch space
     fn process(&self, input: &mut [Complex<T>], output: &mut [Complex<T>]);

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -1,5 +1,5 @@
 
-use num::{Zero, One, FromPrimitive, Integer, PrimInt, Signed};
+use num_traits::{Zero, One, FromPrimitive, PrimInt, Signed};
 use std::mem::swap;
 
 pub fn primitive_root(prime: u64) -> Option<u64> {
@@ -22,11 +22,13 @@ pub fn primitive_root(prime: u64) -> Option<u64> {
 }
 
 /// computes base^exponent % modulo using the standard exponentiation by squaring algorithm
-pub fn modular_exponent<T: PrimInt + Integer>(mut base: T, mut exponent: T, modulo: T) -> T {
-    let mut result = One::one();
+pub fn modular_exponent<T: PrimInt>(mut base: T, mut exponent: T, modulo: T) -> T {
+    let one = T::one();
+
+    let mut result = one;
 
     while exponent > Zero::zero() {
-        if exponent.is_odd() {
+        if exponent & one == one {
             result = result * base % modulo;
         }
         exponent = exponent >> One::one();
@@ -36,7 +38,7 @@ pub fn modular_exponent<T: PrimInt + Integer>(mut base: T, mut exponent: T, modu
     result
 }
 
-pub fn multiplicative_inverse<T: PrimInt + Integer + FromPrimitive>(a: T, n: T) -> T {
+pub fn multiplicative_inverse<T: PrimInt + FromPrimitive>(a: T, n: T) -> T {
     // we're going to use a modified version extended euclidean algorithm
     // we only need half the output
 
@@ -67,7 +69,7 @@ pub fn multiplicative_inverse<T: PrimInt + Integer + FromPrimitive>(a: T, n: T) 
     t
 }
 
-pub fn extended_euclidean_algorithm<T: PrimInt + Integer + Signed + FromPrimitive>(a: T,
+pub fn extended_euclidean_algorithm<T: PrimInt + Signed + FromPrimitive>(a: T,
                                                                                    b: T)
                                                                                    -> (T, T, T) {
     let mut s = Zero::zero();

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -14,15 +14,15 @@ const MIN_RADIX4_BITS: u32 = 8; // minimum size to consider radix 4 an option is
 const BUTTERFLIES: [usize; 8] = [2, 3, 4, 5, 6, 7, 8, 16];
 const COMPOSITE_BUTTERFLIES: [usize; 4] = [4, 6, 8, 16];
 
-pub struct Planner<T> {
+pub struct FFTplanner<T> {
     inverse: bool,
     algorithm_cache: HashMap<usize, Rc<FFT<T>>>,
     butterfly_cache: HashMap<usize, Rc<FFTButterfly<T>>>,
 }
 
-impl<T: FFTnum> Planner<T> {
+impl<T: FFTnum> FFTplanner<T> {
     pub fn new(inverse: bool) -> Self {
-        Planner {
+        FFTplanner {
             inverse: inverse,
             algorithm_cache: HashMap::new(),
             butterfly_cache: HashMap::new(),

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -42,7 +42,7 @@ impl<T: FFTnum> FFTplanner<T> {
         let inverse = self.inverse;
         self.butterfly_cache.entry(len).or_insert_with(|| 
             match len {
-                2 => Rc::new(Butterfly2 {}),
+                2 => Rc::new(Butterfly2::new(inverse)),
                 3 => Rc::new(Butterfly3::new(inverse)),
                 4 => Rc::new(Butterfly4::new(inverse)),
                 5 => Rc::new(Butterfly5::new(inverse)),
@@ -135,14 +135,14 @@ impl<T: FFTnum> FFTplanner<T> {
             let left_fft = self.plan_butterfly(left_len);
             let right_fft = self.plan_butterfly(right_len);
 
-            Rc::new(MixedRadixDoubleButterfly::new(left_fft, right_fft, self.inverse)) as
+            Rc::new(MixedRadixDoubleButterfly::new(left_fft, right_fft)) as
             Rc<FFT<T>>
         } else {
             //neither size is a butterfly, so go with the normal algorithm
             let left_fft = self.plan_fft_with_factors(left_len, left_factors);
             let right_fft = self.plan_fft_with_factors(right_len, right_factors);
 
-            Rc::new(MixedRadix::new(left_fft, right_fft, self.inverse)) as Rc<FFT<T>>
+            Rc::new(MixedRadix::new(left_fft, right_fft)) as Rc<FFT<T>>
         }
     }
 
@@ -150,7 +150,7 @@ impl<T: FFTnum> FFTplanner<T> {
     fn plan_fft_single_factor(&mut self, len: usize) -> Rc<FFT<T>> {
         match len {
             0...1 => Rc::new(DFT::new(len, self.inverse)) as Rc<FFT<T>>,
-            2 => Rc::new(butterflies::Butterfly2 {}) as Rc<FFT<T>>,
+            2 => Rc::new(butterflies::Butterfly2::new(self.inverse)) as Rc<FFT<T>>,
             3 => Rc::new(butterflies::Butterfly3::new(self.inverse)) as Rc<FFT<T>>,
             4 => Rc::new(butterflies::Butterfly4::new(self.inverse)) as Rc<FFT<T>>,
             5 => Rc::new(butterflies::Butterfly5::new(self.inverse)) as Rc<FFT<T>>,
@@ -168,6 +168,6 @@ impl<T: FFTnum> FFTplanner<T> {
 
         let inner_fft = self.plan_fft_with_factors(inner_fft_len, &factors);
 
-        Rc::new(RadersAlgorithm::new(len, inner_fft, self.inverse)) as Rc<FFT<T>>
+        Rc::new(RadersAlgorithm::new(len, inner_fft)) as Rc<FFT<T>>
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -35,6 +35,7 @@ pub fn compare_vectors(vec1: &[Complex<f32>], vec2: &[Complex<f32>]) -> bool {
 
 pub fn check_fft_algorithm(fft: &FFT<f32>, size: usize, inverse: bool) {
     assert_eq!(fft.len(), size, "Algorithm reported incorrect size");
+    assert_eq!(fft.is_inverse(), inverse, "Algorithm reported incorrect inverse value");
 
     let n = 5;
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,4 +1,5 @@
-use num::{Complex, Zero};
+use num_complex::Complex;
+use num_traits::Zero;
 
 use rand::{StdRng, SeedableRng};
 use rand::distributions::{Normal, IndependentSample};

--- a/src/twiddles.rs
+++ b/src/twiddles.rs
@@ -1,6 +1,9 @@
 
 use std::f64;
-use num::{Complex, FromPrimitive, One};
+
+use num_complex::Complex;
+use num_traits::{FromPrimitive, One};
+
 use common::FFTnum;
 
 pub fn generate_twiddle_factors<T: FFTnum>(fft_len: usize, inverse: bool) -> Vec<Complex<T>> {

--- a/tests/accuracy.rs
+++ b/tests/accuracy.rs
@@ -15,7 +15,7 @@ use rustfft::num_traits::Zero;
 
 use rand::{StdRng, SeedableRng};
 use rand::distributions::{Normal, IndependentSample};
-use rustfft::{FFT, Planner};
+use rustfft::{FFT, FFTplanner};
 use rustfft::algorithm::DFT;
 
 /// The seed for the random number generator used to generate
@@ -42,9 +42,9 @@ fn fft_matches_dft(signal: Vec<Complex<f32>>, inverse: bool) -> bool {
     let mut spectrum_dft = vec![Zero::zero(); signal.len()];
     let mut spectrum_fft = vec![Zero::zero(); signal.len()];
 
-    let mut planner = Planner::new(inverse);
+    let mut planner = FFTplanner::new(inverse);
     let fft = planner.plan_fft(signal.len());
-    assert_eq!(fft.len(), signal.len(), "Planner created FFT of wrong length");
+    assert_eq!(fft.len(), signal.len(), "FFTplanner created FFT of wrong length");
 
     fft.process(&mut signal_fft, &mut spectrum_fft);
 

--- a/tests/accuracy.rs
+++ b/tests/accuracy.rs
@@ -4,13 +4,15 @@
 //! for a variety of lengths, and test that our FFT algorithm matches our
 //! DFT calculation for those signals.
 
-extern crate num;
+
 extern crate rustfft;
 extern crate rand;
 
 use std::f32;
 
-use num::{Complex, Zero};
+use rustfft::num_complex::Complex;
+use rustfft::num_traits::Zero;
+
 use rand::{StdRng, SeedableRng};
 use rand::distributions::{Normal, IndependentSample};
 use rustfft::{FFT, Planner};

--- a/tests/accuracy.rs
+++ b/tests/accuracy.rs
@@ -45,6 +45,7 @@ fn fft_matches_dft(signal: Vec<Complex<f32>>, inverse: bool) -> bool {
     let mut planner = FFTplanner::new(inverse);
     let fft = planner.plan_fft(signal.len());
     assert_eq!(fft.len(), signal.len(), "FFTplanner created FFT of wrong length");
+    assert_eq!(fft.is_inverse(), inverse, "FFTplanner created FFT of wrong direction");
 
     fft.process(&mut signal_fft, &mut spectrum_fft);
 


### PR DESCRIPTION
I've been using RustFFT to make my own Discrete Cosine Transform crate: https://github.com/ejmahler/rust_dct

It' still WIP but it's coming along nicely. Based on my experience I think a few more improvements can be made to rustfft's API

- Make FFTnum depend on Debug. This is critical for debugging the workings of generic code that uses rustFFT. when developing rustfft it's simple enough to add it when you need it, and remove it before committing, but it's not that simple when rustfft is an external crate. This shouldn't interfere with any future fixed precision plans, since those should implement debug.
- Rename Planner to FFTplanner -- this is just a naming clarity thing
- Depend on the `num_complex` and `num_traits` crates instead of `num`. This greatly reduces the amount of stuff to download/compile when compiling rustfft. Adding dependencies isn't a breaking change afaik, so if we decide we need other num crates, we can add them individually later
- Re-export the num_traits and num_complex crates. This is so that other crates can `use rustfft::num_complex::Complex;` and be confident they're using the same version of Complex as rustfft itself, without having to manually match up version numbers

Based on my experience so far, these changes will make rustfft easier to use