### PR TITLE
Greatly improve cache-friendliness of size 2^n FFTs

### DIFF
--- a/benches/rustfft.rs
+++ b/benches/rustfft.rs
@@ -17,19 +17,21 @@ fn bench_fft(b: &mut Bencher, len: usize) {
     b.iter(|| {fft.process(&mut signal, &mut spectrum);} );
 }
 
-// Powers of 2
-#[bench] fn complex_p2_00128(b: &mut Bencher) { bench_fft(b,    128); }
-#[bench] fn complex_p2_00512(b: &mut Bencher) { bench_fft(b,   512); }
-#[bench] fn complex_p2_02048(b: &mut Bencher) { bench_fft(b,  2048); }
-#[bench] fn complex_p2_08192(b: &mut Bencher) { bench_fft(b,  8192); }
-#[bench] fn complex_p2_32768(b: &mut Bencher) { bench_fft(b, 32768); }
 
 // Powers of 4
-#[bench] fn complex_p4_00064(b: &mut Bencher) { bench_fft(b,    64); }
-#[bench] fn complex_p4_00256(b: &mut Bencher) { bench_fft(b,   256); }
-#[bench] fn complex_p4_01024(b: &mut Bencher) { bench_fft(b,  1024); }
-#[bench] fn complex_p4_04096(b: &mut Bencher) { bench_fft(b,  4096); }
-#[bench] fn complex_p4_16384(b: &mut Bencher) { bench_fft(b, 16384); }
+#[bench] fn complex_p2_000064(b: &mut Bencher) { bench_fft(b,   64); }
+#[bench] fn complex_p2_000128(b: &mut Bencher) { bench_fft(b,   128); }
+#[bench] fn complex_p2_000256(b: &mut Bencher) { bench_fft(b,   256); }
+#[bench] fn complex_p2_000512(b: &mut Bencher) { bench_fft(b,   512); }
+#[bench] fn complex_p2_001024(b: &mut Bencher) { bench_fft(b,   1024); }
+#[bench] fn complex_p2_002048(b: &mut Bencher) { bench_fft(b,   2048); }
+#[bench] fn complex_p2_004096(b: &mut Bencher) { bench_fft(b,   4096); }
+#[bench] fn complex_p2_008192(b: &mut Bencher) { bench_fft(b,   8192); }
+#[bench] fn complex_p2_016384(b: &mut Bencher) { bench_fft(b,   16384); }
+#[bench] fn complex_p2_032768(b: &mut Bencher) { bench_fft(b,   32768); }
+#[bench] fn complex_p2_065536(b: &mut Bencher) { bench_fft(b,   65536); }
+#[bench] fn complex_p2_1048576(b: &mut Bencher) { bench_fft(b, 1048576); }
+#[bench] fn complex_p2_2097152(b: &mut Bencher) { bench_fft(b, 2097152); }
 
 // Powers of 7
 #[bench] fn complex_p7_00343(b: &mut Bencher) { bench_fft(b,   343); }

--- a/benches/rustfft.rs
+++ b/benches/rustfft.rs
@@ -19,7 +19,6 @@ fn bench_fft(b: &mut Bencher, len: usize) {
 
 
 // Powers of 4
-#[bench] fn complex_p2_00000032(b: &mut Bencher) { bench_fft(b,       32); }
 #[bench] fn complex_p2_00000064(b: &mut Bencher) { bench_fft(b,       64); }
 #[bench] fn complex_p2_00000256(b: &mut Bencher) { bench_fft(b,      256); }
 #[bench] fn complex_p2_00001024(b: &mut Bencher) { bench_fft(b,     1024); }
@@ -27,7 +26,6 @@ fn bench_fft(b: &mut Bencher, len: usize) {
 #[bench] fn complex_p2_00016384(b: &mut Bencher) { bench_fft(b,    16384); }
 #[bench] fn complex_p2_00065536(b: &mut Bencher) { bench_fft(b,    65536); }
 #[bench] fn complex_p2_01048576(b: &mut Bencher) { bench_fft(b,  1048576); }
-#[bench] fn complex_p2_08388608(b: &mut Bencher) { bench_fft(b,  8388608); }
 #[bench] fn complex_p2_16777216(b: &mut Bencher) { bench_fft(b, 16777216); }
 
 

--- a/benches/rustfft.rs
+++ b/benches/rustfft.rs
@@ -19,19 +19,17 @@ fn bench_fft(b: &mut Bencher, len: usize) {
 
 
 // Powers of 4
-#[bench] fn complex_p2_000064(b: &mut Bencher) { bench_fft(b,   64); }
-#[bench] fn complex_p2_000128(b: &mut Bencher) { bench_fft(b,   128); }
-#[bench] fn complex_p2_000256(b: &mut Bencher) { bench_fft(b,   256); }
-#[bench] fn complex_p2_000512(b: &mut Bencher) { bench_fft(b,   512); }
-#[bench] fn complex_p2_001024(b: &mut Bencher) { bench_fft(b,   1024); }
-#[bench] fn complex_p2_002048(b: &mut Bencher) { bench_fft(b,   2048); }
-#[bench] fn complex_p2_004096(b: &mut Bencher) { bench_fft(b,   4096); }
-#[bench] fn complex_p2_008192(b: &mut Bencher) { bench_fft(b,   8192); }
-#[bench] fn complex_p2_016384(b: &mut Bencher) { bench_fft(b,   16384); }
-#[bench] fn complex_p2_032768(b: &mut Bencher) { bench_fft(b,   32768); }
-#[bench] fn complex_p2_065536(b: &mut Bencher) { bench_fft(b,   65536); }
-#[bench] fn complex_p2_1048576(b: &mut Bencher) { bench_fft(b, 1048576); }
-#[bench] fn complex_p2_2097152(b: &mut Bencher) { bench_fft(b, 2097152); }
+#[bench] fn complex_p2_00000032(b: &mut Bencher) { bench_fft(b,       32); }
+#[bench] fn complex_p2_00000064(b: &mut Bencher) { bench_fft(b,       64); }
+#[bench] fn complex_p2_00000256(b: &mut Bencher) { bench_fft(b,      256); }
+#[bench] fn complex_p2_00001024(b: &mut Bencher) { bench_fft(b,     1024); }
+#[bench] fn complex_p2_00004096(b: &mut Bencher) { bench_fft(b,     4096); }
+#[bench] fn complex_p2_00016384(b: &mut Bencher) { bench_fft(b,    16384); }
+#[bench] fn complex_p2_00065536(b: &mut Bencher) { bench_fft(b,    65536); }
+#[bench] fn complex_p2_01048576(b: &mut Bencher) { bench_fft(b,  1048576); }
+#[bench] fn complex_p2_08388608(b: &mut Bencher) { bench_fft(b,  8388608); }
+#[bench] fn complex_p2_16777216(b: &mut Bencher) { bench_fft(b, 16777216); }
+
 
 // Powers of 7
 #[bench] fn complex_p7_00343(b: &mut Bencher) { bench_fft(b,   343); }

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -3,7 +3,7 @@ use num_traits::Zero;
 
 use common::{FFTnum, verify_length, verify_length_divisible};
 
-use algorithm::butterflies::{Butterfly2, Butterfly4, FFTButterfly};
+use algorithm::butterflies::{Butterfly2, Butterfly4, Butterfly8, Butterfly16, FFTButterfly};
 use ::{Length, IsInverse, FFT};
 use twiddles;
 
@@ -25,6 +25,9 @@ use twiddles;
 
 pub struct Radix4<T> {
     twiddles: Box<[Complex<T>]>,
+    butterfly8: Butterfly8<T>,
+    butterfly16: Butterfly16<T>,
+    len: usize,
     inverse: bool,
 }
 
@@ -32,46 +35,89 @@ impl<T: FFTnum> Radix4<T> {
     /// Preallocates necessary arrays and precomputes necessary data to efficiently compute the power-of-two FFT
     pub fn new(len: usize, inverse: bool) -> Self {
         assert!(len.is_power_of_two() && len > 1, "Radix4 algorithm requires a power-of-two input size greater than one. Got {}", len);
+
+        // precompute the twiddle factors this algorithm will use.
+        // we're doing the same precomputation of twiddle factors as the mixed radix algorithm where width=4 and height=len/4
+        // but mixed radix only does one step and then calls itself recusrively, and this algorithm does every layer all the way down
+        // so we're going to pack all the "layers" of twiddle factors into a single array, starting with the bottom and going up
+        let num_bits = len.trailing_zeros();
+        let mut twiddle_stride = if num_bits%2 == 0 {
+            len / 64
+        } else {
+            len / 32
+        };
+
+        let mut twiddle_factors = Vec::with_capacity(len * 2);
+        while twiddle_stride > 0 {
+            let num_rows = len / (twiddle_stride * 4);
+            for i in 0..num_rows {
+                for k in 1..4 {
+                    let twiddle = twiddles::single_twiddle(i * k * twiddle_stride, len, inverse);
+                    twiddle_factors.push(twiddle);
+                }
+            }
+            twiddle_stride >>= 2;
+        }
+
         Radix4 {
-            twiddles: twiddles::generate_twiddle_factors(len, inverse).into_boxed_slice(),
+            twiddles: twiddle_factors.into_boxed_slice(),
+            butterfly8: Butterfly8::new(inverse),
+            butterfly16: Butterfly16::new(inverse),
+            len: len,
             inverse: inverse,
         }
     }
 
     fn perform_fft(&self, signal: &[Complex<T>], spectrum: &mut [Complex<T>]) {
-        // copy the data into the spectrum vector
-        prepare_radix4(signal.len(), signal, spectrum, 1);
+        match self.len() {
+            2 => {
+                spectrum.copy_from_slice(signal);
+                unsafe { Butterfly2::new(self.inverse).process_inplace(spectrum) }
+            },
+            4 => {
+                spectrum.copy_from_slice(signal);
+                unsafe { Butterfly4::new(self.inverse).process_inplace(spectrum) }
+            },
+            _ => {
+                // copy the data into the spectrum vector
+                prepare_radix4(signal.len(), signal, spectrum, 1);
 
-        // perform the butterflies. the butterfly size depends on the input size
-        let num_bits = signal.len().trailing_zeros();
-        let mut current_size = if num_bits % 2 > 0 {
-            let inner_fft = Butterfly2::new(self.inverse);
-            unsafe { inner_fft.process_multi_inplace(spectrum) };
+                // perform the butterflies. the butterfly size depends on the input size
+                let num_bits = signal.len().trailing_zeros();
+                let mut current_size = if num_bits % 2 == 0 {
+                    unsafe { self.butterfly16.process_multi_inplace(spectrum) };
 
-            // for the cross-ffts we want to to start off with a size of 8 (2 * 4)
-            8
-        } else {
-            let inner_fft = Butterfly4::new(self.inverse);
-            unsafe { inner_fft.process_multi_inplace(spectrum) };
+                    // for the cross-ffts we want to to start off with a size of 64 (16 * 4)
+                    64
+                } else {
+                    unsafe { self.butterfly8.process_multi_inplace(spectrum) };
 
-            // for the cross-ffts we want to to start off with a size of 16 (4 * 4)
-            16
-        };
+                    // for the cross-ffts we want to to start off with a size of 32 (8 * 4)
+                    32
+                };
 
-        // now, perform all the cross-FFTs, one "layer" at a time
-        while current_size <= signal.len() {
-            let group_stride = signal.len() / current_size;
+                let mut layer_twiddles: &[Complex<T>] = &self.twiddles;
 
-            for i in 0..group_stride {
-                unsafe {
-                    butterfly_4(&mut spectrum[i * current_size..],
-                                group_stride,
-                                &self.twiddles,
-                                current_size / 4,
-                                self.inverse)
+                // now, perform all the cross-FFTs, one "layer" at a time
+                while current_size <= signal.len() {
+                    let num_rows = signal.len() / current_size;
+
+                    for i in 0..num_rows {
+                        unsafe {
+                            butterfly_4(&mut spectrum[i * current_size..],
+                                        layer_twiddles,
+                                        current_size / 4,
+                                        self.inverse)
+                        }
+                    }
+
+                    //skip past all the twiddle factors used in this layer
+                    let twiddle_offset = (current_size * 3) / 4;
+                    layer_twiddles = &layer_twiddles[twiddle_offset..];
+
+                    current_size *= 4;
                 }
             }
-            current_size *= 4;
         }
     }
 }
@@ -93,7 +139,7 @@ impl<T: FFTnum> FFT<T> for Radix4<T> {
 impl<T> Length for Radix4<T> {
     #[inline(always)]
     fn len(&self) -> usize {
-        self.twiddles.len()
+        self.len
     }
 }
 impl<T> IsInverse for Radix4<T> {
@@ -112,6 +158,16 @@ fn prepare_radix4<T: FFTnum>(size: usize,
                            spectrum: &mut [Complex<T>],
                            stride: usize) {
     match size {
+        16 => unsafe {
+            for i in 0..16 {
+                *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
+            }
+        },
+        8 => unsafe {
+            for i in 0..8 {
+                *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
+            }
+        },
         4 => unsafe {
             for i in 0..4 {
                 *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
@@ -134,20 +190,17 @@ fn prepare_radix4<T: FFTnum>(size: usize,
 }
 
 unsafe fn butterfly_4<T: FFTnum>(data: &mut [Complex<T>],
-                             stride: usize,
                              twiddles: &[Complex<T>],
                              num_ffts: usize,
                              inverse: bool)
 {
     let mut idx = 0usize;
-    let mut tw_idx_1 = 0usize;
-    let mut tw_idx_2 = 0usize;
-    let mut tw_idx_3 = 0usize;
+    let mut tw_idx = 0usize;
     let mut scratch: [Complex<T>; 6] = [Zero::zero(); 6];
     for _ in 0..num_ffts {
-        scratch[0] = data.get_unchecked(idx + 1 * num_ffts) * twiddles[tw_idx_1];
-        scratch[1] = data.get_unchecked(idx + 2 * num_ffts) * twiddles[tw_idx_2];
-        scratch[2] = data.get_unchecked(idx + 3 * num_ffts) * twiddles[tw_idx_3];
+        scratch[0] = data.get_unchecked(idx + 1 * num_ffts) * twiddles[tw_idx];
+        scratch[1] = data.get_unchecked(idx + 2 * num_ffts) * twiddles[tw_idx + 1];
+        scratch[2] = data.get_unchecked(idx + 3 * num_ffts) * twiddles[tw_idx + 2];
         scratch[5] = data.get_unchecked(idx) - scratch[1];
         *data.get_unchecked_mut(idx) = data.get_unchecked(idx) + scratch[1];
         scratch[3] = scratch[0] + scratch[2];
@@ -166,9 +219,7 @@ unsafe fn butterfly_4<T: FFTnum>(data: &mut [Complex<T>],
             data.get_unchecked_mut(idx + 3 * num_ffts).im = scratch[5].im + scratch[4].re;
         }
 
-        tw_idx_1 += 1 * stride;
-        tw_idx_2 += 2 * stride;
-        tw_idx_3 += 3 * stride;
+        tw_idx += 3;
         idx += 1;
     }
 }
@@ -180,7 +231,7 @@ mod unit_tests {
 
     #[test]
     fn test_radix4() {
-        for pow in 1..7 {
+        for pow in 1..8 {
             let len = 1 << pow;
             test_radix4_with_length(len, false);
             test_radix4_with_length(len, true);

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -34,7 +34,7 @@ pub struct Radix4<T> {
 impl<T: FFTnum> Radix4<T> {
     /// Preallocates necessary arrays and precomputes necessary data to efficiently compute the power-of-two FFT
     pub fn new(len: usize, inverse: bool) -> Self {
-        assert!(len.is_power_of_two() && len > 1, "Radix4 algorithm requires a power-of-two input size greater than one. Got {}", len);
+        assert!(len.is_power_of_two(), "Radix4 algorithm requires a power-of-two input size. Got {}", len);
 
         // precompute the twiddle factors this algorithm will use.
         // we're doing the same precomputation of twiddle factors as the mixed radix algorithm where width=4 and height=len/4
@@ -70,6 +70,7 @@ impl<T: FFTnum> Radix4<T> {
 
     fn perform_fft(&self, signal: &[Complex<T>], spectrum: &mut [Complex<T>]) {
         match self.len() {
+            0...1 => spectrum.copy_from_slice(signal),
             2 => {
                 spectrum.copy_from_slice(signal);
                 unsafe { Butterfly2::new(self.inverse).process_inplace(spectrum) }
@@ -231,7 +232,7 @@ mod unit_tests {
 
     #[test]
     fn test_radix4() {
-        for pow in 1..8 {
+        for pow in 0..8 {
             let len = 1 << pow;
             test_radix4_with_length(len, false);
             test_radix4_with_length(len, true);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -10,9 +10,10 @@ use algorithm::butterflies::*;
 use math_utils;
 
 
-const MIN_RADIX4_BITS: u32 = 8; // minimum size to consider radix 4 an option is 2^8 = 256
-const BUTTERFLIES: [usize; 8] = [2, 3, 4, 5, 6, 7, 8, 16];
-const COMPOSITE_BUTTERFLIES: [usize; 4] = [4, 6, 8, 16];
+const MIN_RADIX4_BITS: u32 = 5; // smallest size to consider radix 4 an option is 2^5 = 32
+const MAX_RADIX4_BITS: u32 = 16; // largest size to consider radix 4 an option is 2^16 = 65536
+const BUTTERFLIES: [usize; 9] = [2, 3, 4, 5, 6, 7, 8, 16, 32];
+const COMPOSITE_BUTTERFLIES: [usize; 5] = [4, 6, 8, 16, 32];
 
 /// The FFT planner is used to make new FFT algorithm instances.
 ///
@@ -81,6 +82,7 @@ impl<T: FFTnum> FFTplanner<T> {
                 7 => Arc::new(Butterfly7::new(inverse)),
                 8 => Arc::new(Butterfly8::new(inverse)),
                 16 => Arc::new(Butterfly16::new(inverse)),
+                32 => Arc::new(Butterfly32::new(inverse)),
                 _ => panic!("Invalid butterfly size: {}", len),
             }
         ).clone()
@@ -93,7 +95,7 @@ impl<T: FFTnum> FFTplanner<T> {
             let result = if factors.len() == 1 || COMPOSITE_BUTTERFLIES.contains(&len) {
                 self.plan_fft_single_factor(len)
 
-            } else if len.trailing_zeros() >= MIN_RADIX4_BITS {
+            } else if len.trailing_zeros() <= MAX_RADIX4_BITS && len.trailing_zeros() >= MIN_RADIX4_BITS {
                 //the number of trailing zeroes in len is the number of `2` factors
                 //ie if len = 2048 * n, len.trailing_zeros() will equal 11 because 2^11 == 2048
 
@@ -189,6 +191,7 @@ impl<T: FFTnum> FFTplanner<T> {
             7 => Arc::new(butterflies::Butterfly7::new(self.inverse)) as Arc<FFT<T>>,
             8 => Arc::new(butterflies::Butterfly8::new(self.inverse)) as Arc<FFT<T>>,
             16 => Arc::new(butterflies::Butterfly16::new(self.inverse)) as Arc<FFT<T>>,
+            32 => Arc::new(butterflies::Butterfly32::new(self.inverse)) as Arc<FFT<T>>,
             _ => self.plan_prime(len),
         }
     }


### PR DESCRIPTION
This PR does 4 main things:
- Rewrites Butterfly16 to use a split--2-4-radix setup instead of mixed radix, for a 2x speedup, and adds a butterfly32 with the same design
- Rewrites Radix4 to use Butterfly8 and Butterfly16 as a base case instead of Butterfly2 and Butterfly. This improves the speed at small sizes
- Rewrites Radix4 twiddle factors so that instead of having a fixed list that it scans over with different strides, it groups the twiddles each layer needs into a block that is accessed with a stride of 1. This takes more memory, but gives a 10-20% improvement at larger sizes.
- Places an upper limit in the planner on which sizes will use radix 4. Above 2^16, it uses mixed radix instead. This has a huge effect when the problem doesn't fit into cache, because I write the mixed radix algorithm to be very cache friendly.

Benchmarks before:
test complex_p2_00000064       ... bench:         271 ns/iter (+/- 33)
test complex_p2_00000256       ... bench:       1,735 ns/iter (+/- 150)
test complex_p2_00001024       ... bench:       8,509 ns/iter (+/- 758)
test complex_p2_00004096       ... bench:      41,676 ns/iter (+/- 3,838)
test complex_p2_00016384       ... bench:     201,696 ns/iter (+/- 18,394)
test complex_p2_00065536       ... bench:   1,052,056 ns/iter (+/- 100,591)
test complex_p2_01048576       ... bench:  40,949,208 ns/iter (+/- 2,464,292)
test complex_p2_16777216       ... bench: 1,554,480,456 ns/iter (+/- 22,497,409)

Benchmarks after:
test complex_p2_00000064       ... bench:         265 ns/iter (+/- 45)
test complex_p2_00000256       ... bench:       1,390 ns/iter (+/- 139)
test complex_p2_00001024       ... bench:       7,013 ns/iter (+/- 608)
test complex_p2_00004096       ... bench:      35,085 ns/iter (+/- 2,444)
test complex_p2_00016384       ... bench:     173,429 ns/iter (+/- 15,180)
test complex_p2_00065536       ... bench:     812,941 ns/iter (+/- 73,863)
test complex_p2_01048576       ... bench:  20,780,458 ns/iter (+/- 1,263,067)
test complex_p2_16777216       ... bench: 409,238,648 ns/iter (+/- 13,505,602)

2^16 to 2^18 is the point where the whole thing stops fitting in L3 cache, and as far as i can tell, the higher you go, the more dramatic the improvement