### PR TITLE
Best practices: Replace arc_instance.clone() with Arc::clone(&arc_instance)

### DIFF
--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -3,6 +3,7 @@
 extern crate rustfft;
 
 use std::thread;
+use std::sync::Arc;
 
 use rustfft::FFTplanner;
 use rustfft::num_complex::Complex32;
@@ -13,7 +14,7 @@ fn main() {
     let fft = planner.plan_fft(100);
 
     let threads: Vec<thread::JoinHandle<_>> = (0..2).map(|_| {
-        let fft_copy = fft.clone();
+        let fft_copy = Arc::clone(&fft);
         thread::spawn(move || {
             let mut signal = vec![Complex32::new(0.0, 0.0); 100];
             let mut spectrum = vec![Complex32::new(0.0, 0.0); 100];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //!
 //! ```
 //! // Perform a forward FFT of size 1234
+//! use std::sync::Arc;
 //! use rustfft::FFTplanner;
 //! use rustfft::num_complex::Complex;
 //! use rustfft::num_traits::Zero;
@@ -18,6 +19,9 @@
 //! let mut planner = FFTplanner::new(false);
 //! let fft = planner.plan_fft(1234);
 //! fft.process(&mut input, &mut output);
+//! 
+//! // The fft instance returned by the planner is stored behind an `Arc`, so it's cheap to clone
+//! let fft_clone = Arc::clone(&fft);
 //! ```
 //! The planner returns trait objects of the [`FFT`](trait.FFT.html) trait, allowing for FFT sizes that aren't known
 //! until runtime.


### PR DESCRIPTION
The documentation for `Arc` recommends using `Arc::clone(&instance)`

https://doc.rust-lang.org/std/sync/struct.Arc.html

> The Arc::clone(&from) syntax is the most idiomatic because it conveys more explicitly the meaning of the code. In the example above, this syntax makes it easier to see that this code is creating a new reference rather than copying the whole content of foo.

This also adds a couple lines to the docs, showing that `Arc`s are returned