### PR TITLE
[Breaking Change] Change item names to suit rust naming conventions

### DIFF
--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -4,12 +4,12 @@ extern crate rustfft;
 
 use std::thread;
 
-use rustfft::FFTplanner;
+use rustfft::FftPlanner;
 use rustfft::num_complex::Complex32;
 
 fn main() {
     let inverse = false;
-    let mut planner = FFTplanner::new(inverse);
+    let mut planner = FftPlanner::new(inverse);
     let fft = planner.plan_fft(100);
 
     let threads: Vec<thread::JoinHandle<_>> = (0..2).map(|_| {

--- a/src/algorithm/dft.rs
+++ b/src/algorithm/dft.rs
@@ -1,9 +1,9 @@
 use num_complex::Complex;
 use num_traits::Zero;
 
-use common::{FFTnum, verify_length, verify_length_divisible};
+use common::{FftNum, verify_length, verify_length_divisible};
 
-use ::{Length, IsInverse, FFT};
+use ::{Length, IsInverse, Fft};
 use twiddles;
 
 /// Naive O(n^2 ) Discrete Fourier Transform implementation
@@ -14,26 +14,26 @@ use twiddles;
 ///
 /// ~~~
 /// // Computes a naive DFT of size 1234
-/// use rustfft::algorithm::DFT;
-/// use rustfft::FFT;
+/// use rustfft::algorithm::Dft;
+/// use rustfft::Fft;
 /// use rustfft::num_complex::Complex;
 /// use rustfft::num_traits::Zero;
 ///
 /// let mut input:  Vec<Complex<f32>> = vec![Zero::zero(); 1234];
 /// let mut output: Vec<Complex<f32>> = vec![Zero::zero(); 1234];
 ///
-/// let dft = DFT::new(1234, false);
+/// let dft = Dft::new(1234, false);
 /// dft.process(&mut input, &mut output);
 /// ~~~
-pub struct DFT<T> {
+pub struct Dft<T> {
     twiddles: Vec<Complex<T>>,
     inverse: bool,
 }
 
-impl<T: FFTnum> DFT<T> {
+impl<T: FftNum> Dft<T> {
     /// Preallocates necessary arrays and precomputes necessary data to efficiently compute DFT
     pub fn new(len: usize, inverse: bool) -> Self {
-        DFT {
+        Dft {
             twiddles: twiddles::generate_twiddle_factors(len, inverse),
             inverse: inverse
         }
@@ -60,7 +60,7 @@ impl<T: FFTnum> DFT<T> {
     }
 }
 
-impl<T: FFTnum> FFT<T> for DFT<T> {
+impl<T: FftNum> Fft<T> for Dft<T> {
     fn process(&self, input: &mut [Complex<T>], output: &mut [Complex<T>]) {
         verify_length(input, output, self.len());
 
@@ -74,13 +74,13 @@ impl<T: FFTnum> FFT<T> for DFT<T> {
         }
     }
 }
-impl<T> Length for DFT<T> {
+impl<T> Length for Dft<T> {
     #[inline(always)]
     fn len(&self) -> usize {
         self.twiddles.len()
     }
 }
-impl<T> IsInverse for DFT<T> {
+impl<T> IsInverse for Dft<T> {
     #[inline(always)]
     fn is_inverse(&self) -> bool {
         self.inverse
@@ -113,8 +113,8 @@ mod unit_tests {
         let n = 4;
 
         for len in 1..20 {
-            let dft_instance = DFT::new(len, false);
-            assert_eq!(dft_instance.len(), len, "DFT instance reported incorrect length");
+            let dft_instance = Dft::new(len, false);
+            assert_eq!(dft_instance.len(), len, "Dft instance reported incorrect length");
 
             let mut expected_input = random_signal(len * n);
             let mut actual_input = expected_input.clone();
@@ -140,7 +140,7 @@ mod unit_tests {
         }
 
         //verify that it doesn't crash if we have a length of 0
-        let zero_dft = DFT::new(0, false);
+        let zero_dft = Dft::new(0, false);
         let mut zero_input: Vec<Complex<f32>> = Vec::new();
         let mut zero_output: Vec<Complex<f32>> = Vec::new();
 
@@ -148,7 +148,7 @@ mod unit_tests {
     }
 
     /// Returns true if our `dft` function calculates the given spectrum from the
-    /// given signal, and if rustfft's DFT struct does the same
+    /// given signal, and if rustfft's Dft struct does the same
     fn test_dft_correct(signal: &[Complex<f32>], spectrum: &[Complex<f32>]) -> bool {
         assert_eq!(signal.len(), spectrum.len());
 
@@ -160,7 +160,7 @@ mod unit_tests {
 
         dft(&expected_signal, &mut expected_spectrum);
 
-        let dft_instance = DFT::new(signal.len(), false);
+        let dft_instance = Dft::new(signal.len(), false);
         dft_instance.process(&mut actual_signal, &mut actual_spectrum);
 
         return compare_vectors(spectrum, &expected_spectrum) && compare_vectors(spectrum, &actual_spectrum);

--- a/src/algorithm/good_thomas_algorithm.rs
+++ b/src/algorithm/good_thomas_algorithm.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
 use num_complex::Complex;
-use common::{FFTnum, verify_length, verify_length_divisible};
+use common::{FftNum, verify_length, verify_length_divisible};
 
 use math_utils;
 use array_utils;
 
-use ::{Length, IsInverse, FFT};
+use ::{Length, IsInverse, Fft};
 
 /// Implementation of the [Good-Thomas Algorithm (AKA Prime Factor Algorithm)](https://en.wikipedia.org/wiki/Prime-factor_FFT_algorithm)
 ///
@@ -18,7 +18,7 @@ use ::{Length, IsInverse, FFT};
 /// ~~~
 /// // Computes a forward FFT of size 1200, using the Good-Thomas Algorithm
 /// use rustfft::algorithm::GoodThomasAlgorithm;
-/// use rustfft::{FFT, FFTplanner};
+/// use rustfft::{Fft, FftPlanner};
 /// use rustfft::num_complex::Complex;
 /// use rustfft::num_traits::Zero;
 ///
@@ -27,7 +27,7 @@ use ::{Length, IsInverse, FFT};
 ///
 /// // we need to find an n1 and n2 such that n1 * n2 == 1200 and GCD(n1, n2) == 1
 /// // n1 = 48 and n2 = 25 satisfies this
-/// let mut planner = FFTplanner::new(false);
+/// let mut planner = FftPlanner::new(false);
 /// let inner_fft_n1 = planner.plan_fft(48);
 /// let inner_fft_n2 = planner.plan_fft(25);
 ///
@@ -38,11 +38,11 @@ use ::{Length, IsInverse, FFT};
 pub struct GoodThomasAlgorithm<T> {
     width: usize,
     // width_inverse: usize,
-    width_size_fft: Arc<FFT<T>>,
+    width_size_fft: Arc<Fft<T>>,
 
     height: usize,
     // height_inverse: usize,
-    height_size_fft: Arc<FFT<T>>,
+    height_size_fft: Arc<Fft<T>>,
 
     input_map: Box<[usize]>,
     output_map: Box<[usize]>,
@@ -50,11 +50,11 @@ pub struct GoodThomasAlgorithm<T> {
     inverse: bool,
 }
 
-impl<T: FFTnum> GoodThomasAlgorithm<T> {
-    /// Creates a FFT instance which will process inputs/outputs of size `n1_fft.len() * n2_fft.len()`
+impl<T: FftNum> GoodThomasAlgorithm<T> {
+    /// Creates a Fft instance which will process inputs/outputs of size `n1_fft.len() * n2_fft.len()`
     ///
     /// GCD(n1.len(), n2.len()) must be equal to 1
-    pub fn new(n1_fft: Arc<FFT<T>>, n2_fft: Arc<FFT<T>>) -> Self {
+    pub fn new(n1_fft: Arc<Fft<T>>, n2_fft: Arc<Fft<T>>) -> Self {
         assert_eq!(
             n1_fft.is_inverse(), n2_fft.is_inverse(), 
             "n1_fft and n2_fft must both be inverse, or neither. got n1 inverse={}, n2 inverse={}",
@@ -133,7 +133,7 @@ impl<T: FFTnum> GoodThomasAlgorithm<T> {
     }
 }
 
-impl<T: FFTnum> FFT<T> for GoodThomasAlgorithm<T> {
+impl<T: FftNum> Fft<T> for GoodThomasAlgorithm<T> {
     fn process(&self, input: &mut [Complex<T>], output: &mut [Complex<T>]) {
         verify_length(input, output, self.len());
 
@@ -166,7 +166,7 @@ mod unit_tests {
     use super::*;
     use std::sync::Arc;
     use test_utils::check_fft_algorithm;
-    use algorithm::DFT;
+    use algorithm::Dft;
 
     #[test]
     fn test_good_thomas() {
@@ -184,8 +184,8 @@ mod unit_tests {
     }
 
     fn test_good_thomas_with_lengths(width: usize, height: usize) {
-        let width_fft = Arc::new(DFT::new(width, false)) as Arc<FFT<f32>>;
-        let height_fft = Arc::new(DFT::new(height, false)) as Arc<FFT<f32>>;
+        let width_fft = Arc::new(Dft::new(width, false)) as Arc<Fft<f32>>;
+        let height_fft = Arc::new(Dft::new(height, false)) as Arc<Fft<f32>>;
 
         let fft = GoodThomasAlgorithm::new(width_fft, height_fft);
 

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -11,4 +11,4 @@ pub use self::mixed_radix::{MixedRadix, MixedRadixDoubleButterfly};
 pub use self::raders_algorithm::RadersAlgorithm;
 pub use self::radix4::Radix4;
 pub use self::good_thomas_algorithm::GoodThomasAlgorithm;
-pub use self::dft::DFT;
+pub use self::dft::Dft;

--- a/src/algorithm/raders_algorithm.rs
+++ b/src/algorithm/raders_algorithm.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use num_complex::Complex;
 use num_traits::{FromPrimitive, Zero};
 
-use common::{FFTnum, verify_length, verify_length_divisible};
+use common::{FftNum, verify_length, verify_length_divisible};
 
 use math_utils;
 use twiddles;
-use ::{Length, IsInverse, FFT};
+use ::{Length, IsInverse, Fft};
 
 /// Implementation of Rader's Algorithm
 ///
@@ -20,7 +20,7 @@ use ::{Length, IsInverse, FFT};
 /// ~~~
 /// // Computes a forward FFT of size 1201 (prime number), using Rader's Algorithm
 /// use rustfft::algorithm::RadersAlgorithm;
-/// use rustfft::{FFT, FFTplanner};
+/// use rustfft::{Fft, FftPlanner};
 /// use rustfft::num_complex::Complex;
 /// use rustfft::num_traits::Zero;
 ///
@@ -28,7 +28,7 @@ use ::{Length, IsInverse, FFT};
 /// let mut output: Vec<Complex<f32>> = vec![Zero::zero(); 1201];
 ///
 /// // plan a FFT of size n - 1 = 1200
-/// let mut planner = FFTplanner::new(false);
+/// let mut planner = FftPlanner::new(false);
 /// let inner_fft = planner.plan_fft(1200);
 ///
 /// let fft = RadersAlgorithm::new(1201, inner_fft);
@@ -40,22 +40,22 @@ use ::{Length, IsInverse, FFT};
 /// that it takes 2.5x more time to compute than a FFT of size 1200.
 
 pub struct RadersAlgorithm<T> {
-    inner_fft: Arc<FFT<T>>,
+    inner_fft: Arc<Fft<T>>,
     inner_fft_data: Box<[Complex<T>]>,
 
     input_map: Box<[usize]>,
     output_map: Box<[usize]>,
 }
 
-impl<T: FFTnum> RadersAlgorithm<T> {
-    /// Creates a FFT instance which will process inputs/outputs of size `len`. `inner_fft.len()` must be `len - 1`
+impl<T: FftNum> RadersAlgorithm<T> {
+    /// Creates a Fft instance which will process inputs/outputs of size `len`. `inner_fft.len()` must be `len - 1`
     ///
     /// Note that this constructor is quite expensive to run; This algorithm must run a FFT of size n - 1 within the
     /// constructor. This further underlines the fact that Rader's Algorithm is more expensive to run than other
     /// FFT algorithms
     ///
     /// Note also that if `len` is not prime, this algorithm may silently produce garbage output
-    pub fn new(len: usize, inner_fft: Arc<FFT<T>>) -> Self {
+    pub fn new(len: usize, inner_fft: Arc<Fft<T>>) -> Self {
         assert_eq!(len - 1, inner_fft.len(), "For raders algorithm, inner_fft.len() must be self.len() - 1. Expected {}, got {}", len - 1, inner_fft.len());
 
         let inner_fft_len = len - 1;
@@ -135,7 +135,7 @@ impl<T: FFTnum> RadersAlgorithm<T> {
     }
 }
 
-impl<T: FFTnum> FFT<T> for RadersAlgorithm<T> {
+impl<T: FftNum> Fft<T> for RadersAlgorithm<T> {
     fn process(&self, input: &mut [Complex<T>], output: &mut [Complex<T>]) {
         verify_length(input, output, self.len());
 
@@ -167,7 +167,7 @@ mod unit_tests {
     use super::*;
     use std::sync::Arc;
     use test_utils::check_fft_algorithm;
-    use algorithm::DFT;
+    use algorithm::Dft;
 
     #[test]
     fn test_raders() {
@@ -178,7 +178,7 @@ mod unit_tests {
     }
 
     fn test_raders_with_length(len: usize, inverse: bool) {
-        let inner_fft = Arc::new(DFT::new(len - 1, inverse));
+        let inner_fft = Arc::new(Dft::new(len - 1, inverse));
         let fft = RadersAlgorithm::new(len, inner_fft);
 
         check_fft_algorithm(&fft, len, inverse);

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -1,10 +1,10 @@
 use num_complex::Complex;
 use num_traits::Zero;
 
-use common::{FFTnum, verify_length, verify_length_divisible};
+use common::{FftNum, verify_length, verify_length_divisible};
 
-use algorithm::butterflies::{Butterfly2, Butterfly4, Butterfly8, Butterfly16, FFTButterfly};
-use ::{Length, IsInverse, FFT};
+use algorithm::butterflies::{Butterfly2, Butterfly4, Butterfly8, Butterfly16, FftButterfly};
+use ::{Length, IsInverse, Fft};
 use twiddles;
 
 /// FFT algorithm optimized for power-of-two sizes
@@ -12,7 +12,7 @@ use twiddles;
 /// ~~~
 /// // Computes a forward FFT of size 4096
 /// use rustfft::algorithm::Radix4;
-/// use rustfft::FFT;
+/// use rustfft::Fft;
 /// use rustfft::num_complex::Complex;
 /// use rustfft::num_traits::Zero;
 ///
@@ -31,7 +31,7 @@ pub struct Radix4<T> {
     inverse: bool,
 }
 
-impl<T: FFTnum> Radix4<T> {
+impl<T: FftNum> Radix4<T> {
     /// Preallocates necessary arrays and precomputes necessary data to efficiently compute the power-of-two FFT
     pub fn new(len: usize, inverse: bool) -> Self {
         assert!(len.is_power_of_two(), "Radix4 algorithm requires a power-of-two input size. Got {}", len);
@@ -123,7 +123,7 @@ impl<T: FFTnum> Radix4<T> {
     }
 }
 
-impl<T: FFTnum> FFT<T> for Radix4<T> {
+impl<T: FftNum> Fft<T> for Radix4<T> {
     fn process(&self, input: &mut [Complex<T>], output: &mut [Complex<T>]) {
         verify_length(input, output, self.len());
 
@@ -154,7 +154,7 @@ impl<T> IsInverse for Radix4<T> {
 
 // after testing an iterative bit reversal algorithm, this recursive algorithm
 // was almost an order of magnitude faster at setting up
-fn prepare_radix4<T: FFTnum>(size: usize,
+fn prepare_radix4<T: FftNum>(size: usize,
                            signal: &[Complex<T>],
                            spectrum: &mut [Complex<T>],
                            stride: usize) {
@@ -190,7 +190,7 @@ fn prepare_radix4<T: FFTnum>(size: usize,
     }
 }
 
-unsafe fn butterfly_4<T: FFTnum>(data: &mut [Complex<T>],
+unsafe fn butterfly_4<T: FftNum>(data: &mut [Complex<T>],
                              twiddles: &[Complex<T>],
                              num_ffts: usize,
                              inverse: bool)

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,10 +1,10 @@
 use num_traits::{FromPrimitive, Signed};
 
 /// Generic floating point number, implemnted for f32 and f64
-pub trait FFTnum: Copy + FromPrimitive + Signed + Sync + Send + 'static {}
+pub trait FftNum: Copy + FromPrimitive + Signed + Sync + Send + 'static {}
 
-impl FFTnum for f32 {}
-impl FFTnum for f64 {}
+impl FftNum for f32 {}
+impl FftNum for f64 {}
 
 
 #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,24 +2,24 @@
 
 //! RustFFT allows users to compute arbitrary-sized FFTs in O(nlogn) time.
 //!
-//! The recommended way to use RustFFT is to create a [`FFTplanner`](struct.FFTplanner.html) instance and then call its
+//! The recommended way to use RustFFT is to create a [`FftPlanner`](struct.FftPlanner.html) instance and then call its
 //! `plan_fft` method. This method will automatically choose which FFT algorithms are best
 //! for a given size and initialize the required buffers and precomputed data.
 //!
 //! ```
 //! // Perform a forward FFT of size 1234
-//! use rustfft::FFTplanner;
+//! use rustfft::FftPlanner;
 //! use rustfft::num_complex::Complex;
 //! use rustfft::num_traits::Zero;
 //!
 //! let mut input:  Vec<Complex<f32>> = vec![Complex::zero(); 1234];
 //! let mut output: Vec<Complex<f32>> = vec![Complex::zero(); 1234];
 //!
-//! let mut planner = FFTplanner::new(false);
+//! let mut planner = FftPlanner::new(false);
 //! let fft = planner.plan_fft(1234);
 //! fft.process(&mut input, &mut output);
 //! ```
-//! The planner returns trait objects of the [`FFT`](trait.FFT.html) trait, allowing for FFT sizes that aren't known
+//! The planner returns trait objects of the [`Fft`](trait.Fft.html) trait, allowing for FFT sizes that aren't known
 //! until runtime.
 //! 
 //! RustFFT also exposes individual FFT algorithms. If you know beforehand that you need a power-of-two FFT, you can
@@ -28,7 +28,7 @@
 //! ```
 //! // Computes a forward FFT of size 4096
 //! use rustfft::algorithm::Radix4;
-//! use rustfft::FFT;
+//! use rustfft::Fft;
 //! use rustfft::num_complex::Complex;
 //! use rustfft::num_traits::Zero;
 //!
@@ -39,7 +39,7 @@
 //! fft.process(&mut input, &mut output);
 //! ```
 //!
-//! For the vast majority of situations, simply using the [`FFTplanner`](struct.FFTplanner.html) will be enough, but
+//! For the vast majority of situations, simply using the [`FftPlanner`](struct.FftPlanner.html) will be enough, but
 //! advanced users may have better insight than the planner into which algorithms are best for a specific size. See the
 //! [`algorithm`](algorithm/index.html) module for a complete list of algorithms implemented by RustFFT.
 
@@ -58,8 +58,8 @@ mod common;
 
 use num_complex::Complex;
 
-pub use plan::FFTplanner;
-pub use common::FFTnum;
+pub use plan::FftPlanner;
+pub use common::FftNum;
 
 
 
@@ -76,7 +76,7 @@ pub trait IsInverse {
 }
 
 /// An umbrella trait for all available FFT algorithms
-pub trait FFT<T: FFTnum>: Length + IsInverse + Sync + Send {
+pub trait Fft<T: FftNum>: Length + IsInverse + Sync + Send {
     /// Computes an FFT on the `input` buffer and places the result in the `output` buffer.
     ///
     /// This method uses the `input` buffer as scratch space, so the contents of `input` should be considered garbage

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use common::FFTnum;
+use common::FftNum;
 
-use FFT;
+use Fft;
 use algorithm::*;
 use algorithm::butterflies::*;
 
@@ -17,19 +17,19 @@ const COMPOSITE_BUTTERFLIES: [usize; 5] = [4, 6, 8, 16, 32];
 
 /// The FFT planner is used to make new FFT algorithm instances.
 ///
-/// RustFFT has several FFT algorithms available; For a given FFT size, the FFTplanner decides which of the
+/// RustFFT has several FFT algorithms available; For a given FFT size, the FftPlanner decides which of the
 /// available FFT algorithms to use and then initializes them.
 ///
 /// ~~~
 /// // Perform a forward FFT of size 1234
-/// use rustfft::FFTplanner;
+/// use rustfft::FftPlanner;
 /// use rustfft::num_complex::Complex;
 /// use rustfft::num_traits::Zero;
 ///
 /// let mut input:  Vec<Complex<f32>> = vec![Zero::zero(); 1234];
 /// let mut output: Vec<Complex<f32>> = vec![Zero::zero(); 1234];
 ///
-/// let mut planner = FFTplanner::new(false);
+/// let mut planner = FftPlanner::new(false);
 /// let fft = planner.plan_fft(1234);
 /// fft.process(&mut input, &mut output);
 /// ~~~
@@ -41,18 +41,18 @@ const COMPOSITE_BUTTERFLIES: [usize; 5] = [4, 6, 8, 16, 32];
 ///
 /// Each FFT instance owns `Arc`s to its internal data, rather than borrowing it from the planner, so it's perfectly
 /// safe to drop the planner after creating FFT instances.
-pub struct FFTplanner<T> {
+pub struct FftPlanner<T> {
     inverse: bool,
-    algorithm_cache: HashMap<usize, Arc<FFT<T>>>,
-    butterfly_cache: HashMap<usize, Arc<FFTButterfly<T>>>,
+    algorithm_cache: HashMap<usize, Arc<Fft<T>>>,
+    butterfly_cache: HashMap<usize, Arc<FftButterfly<T>>>,
 }
 
-impl<T: FFTnum> FFTplanner<T> {
+impl<T: FftNum> FftPlanner<T> {
     /// Creates a new FFT planner.
     ///
     /// If `inverse` is false, this planner will plan forward FFTs. If `inverse` is true, it will plan inverse FFTs.
     pub fn new(inverse: bool) -> Self {
-        FFTplanner {
+        FftPlanner {
             inverse: inverse,
             algorithm_cache: HashMap::new(),
             butterfly_cache: HashMap::new(),
@@ -61,16 +61,16 @@ impl<T: FFTnum> FFTplanner<T> {
 
     /// Returns a FFT instance which processes signals of size `len`
     /// If this is called multiple times, it will attempt to re-use internal data between instances
-    pub fn plan_fft(&mut self, len: usize) -> Arc<FFT<T>> {
+    pub fn plan_fft(&mut self, len: usize) -> Arc<Fft<T>> {
         if len < 2 {
-            Arc::new(DFT::new(len, self.inverse)) as Arc<FFT<T>>
+            Arc::new(Dft::new(len, self.inverse)) as Arc<Fft<T>>
         } else {
             let factors = math_utils::prime_factors(len);
             self.plan_fft_with_factors(len, &factors)
         }
     }
 
-    fn plan_butterfly(&mut self, len: usize) -> Arc<FFTButterfly<T>> {
+    fn plan_butterfly(&mut self, len: usize) -> Arc<FftButterfly<T>> {
         let inverse = self.inverse;
         self.butterfly_cache.entry(len).or_insert_with(|| 
             match len {
@@ -88,7 +88,7 @@ impl<T: FFTnum> FFTplanner<T> {
         ).clone()
     }
     
-    fn plan_fft_with_factors(&mut self, len: usize, factors: &[usize]) -> Arc<FFT<T>> {
+    fn plan_fft_with_factors(&mut self, len: usize, factors: &[usize]) -> Arc<Fft<T>> {
         if self.algorithm_cache.contains_key(&len) {
             self.algorithm_cache.get(&len).unwrap().clone()
         } else {
@@ -158,7 +158,7 @@ impl<T: FFTnum> FFTplanner<T> {
                         left_factors: &[usize],
                         right_len: usize,
                         right_factors: &[usize])
-                        -> Arc<FFT<T>> {
+                        -> Arc<Fft<T>> {
 
         let left_is_butterfly = BUTTERFLIES.contains(&left_len);
         let right_is_butterfly = BUTTERFLIES.contains(&right_len);
@@ -169,39 +169,39 @@ impl<T: FFTnum> FFTplanner<T> {
             let right_fft = self.plan_butterfly(right_len);
 
             Arc::new(MixedRadixDoubleButterfly::new(left_fft, right_fft)) as
-            Arc<FFT<T>>
+            Arc<Fft<T>>
         } else {
             //neither size is a butterfly, so go with the normal algorithm
             let left_fft = self.plan_fft_with_factors(left_len, left_factors);
             let right_fft = self.plan_fft_with_factors(right_len, right_factors);
 
-            Arc::new(MixedRadix::new(left_fft, right_fft)) as Arc<FFT<T>>
+            Arc::new(MixedRadix::new(left_fft, right_fft)) as Arc<Fft<T>>
         }
     }
 
 
-    fn plan_fft_single_factor(&mut self, len: usize) -> Arc<FFT<T>> {
+    fn plan_fft_single_factor(&mut self, len: usize) -> Arc<Fft<T>> {
         match len {
-            0...1 => Arc::new(DFT::new(len, self.inverse)) as Arc<FFT<T>>,
-            2 => Arc::new(butterflies::Butterfly2::new(self.inverse)) as Arc<FFT<T>>,
-            3 => Arc::new(butterflies::Butterfly3::new(self.inverse)) as Arc<FFT<T>>,
-            4 => Arc::new(butterflies::Butterfly4::new(self.inverse)) as Arc<FFT<T>>,
-            5 => Arc::new(butterflies::Butterfly5::new(self.inverse)) as Arc<FFT<T>>,
-            6 => Arc::new(butterflies::Butterfly6::new(self.inverse)) as Arc<FFT<T>>,
-            7 => Arc::new(butterflies::Butterfly7::new(self.inverse)) as Arc<FFT<T>>,
-            8 => Arc::new(butterflies::Butterfly8::new(self.inverse)) as Arc<FFT<T>>,
-            16 => Arc::new(butterflies::Butterfly16::new(self.inverse)) as Arc<FFT<T>>,
-            32 => Arc::new(butterflies::Butterfly32::new(self.inverse)) as Arc<FFT<T>>,
+            0...1 => Arc::new(Dft::new(len, self.inverse)) as Arc<Fft<T>>,
+            2 => Arc::new(butterflies::Butterfly2::new(self.inverse)) as Arc<Fft<T>>,
+            3 => Arc::new(butterflies::Butterfly3::new(self.inverse)) as Arc<Fft<T>>,
+            4 => Arc::new(butterflies::Butterfly4::new(self.inverse)) as Arc<Fft<T>>,
+            5 => Arc::new(butterflies::Butterfly5::new(self.inverse)) as Arc<Fft<T>>,
+            6 => Arc::new(butterflies::Butterfly6::new(self.inverse)) as Arc<Fft<T>>,
+            7 => Arc::new(butterflies::Butterfly7::new(self.inverse)) as Arc<Fft<T>>,
+            8 => Arc::new(butterflies::Butterfly8::new(self.inverse)) as Arc<Fft<T>>,
+            16 => Arc::new(butterflies::Butterfly16::new(self.inverse)) as Arc<Fft<T>>,
+            32 => Arc::new(butterflies::Butterfly32::new(self.inverse)) as Arc<Fft<T>>,
             _ => self.plan_prime(len),
         }
     }
 
-    fn plan_prime(&mut self, len: usize) -> Arc<FFT<T>> {
+    fn plan_prime(&mut self, len: usize) -> Arc<Fft<T>> {
         let inner_fft_len = len - 1;
         let factors = math_utils::prime_factors(inner_fft_len);
 
         let inner_fft = self.plan_fft_with_factors(inner_fft_len, &factors);
 
-        Arc::new(RadersAlgorithm::new(len, inner_fft)) as Arc<FFT<T>>
+        Arc::new(RadersAlgorithm::new(len, inner_fft)) as Arc<Fft<T>>
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -4,8 +4,8 @@ use num_traits::Zero;
 use rand::{StdRng, SeedableRng};
 use rand::distributions::{Normal, IndependentSample};
 
-use algorithm::DFT;
-use FFT;
+use algorithm::Dft;
+use Fft;
 
 
 /// The seed for the random number generator used to generate
@@ -33,14 +33,14 @@ pub fn compare_vectors(vec1: &[Complex<f32>], vec2: &[Complex<f32>]) -> bool {
     return (sse / vec1.len() as f32) < 0.1f32;
 }
 
-pub fn check_fft_algorithm(fft: &FFT<f32>, size: usize, inverse: bool) {
+pub fn check_fft_algorithm(fft: &Fft<f32>, size: usize, inverse: bool) {
     assert_eq!(fft.len(), size, "Algorithm reported incorrect size");
     assert_eq!(fft.is_inverse(), inverse, "Algorithm reported incorrect inverse value");
 
     let n = 5;
 
     //test the forward direction
-    let dft = DFT::new(size, inverse);
+    let dft = Dft::new(size, inverse);
 
     // set up buffers
     let mut expected_input = random_signal(size * n);

--- a/src/twiddles.rs
+++ b/src/twiddles.rs
@@ -4,14 +4,14 @@ use std::f64;
 use num_complex::Complex;
 use num_traits::{FromPrimitive, One};
 
-use common::FFTnum;
+use common::FftNum;
 
-pub fn generate_twiddle_factors<T: FFTnum>(fft_len: usize, inverse: bool) -> Vec<Complex<T>> {
+pub fn generate_twiddle_factors<T: FftNum>(fft_len: usize, inverse: bool) -> Vec<Complex<T>> {
     (0..fft_len).map(|i| single_twiddle(i, fft_len, inverse)).collect()
 }
 
 #[inline(always)]
-pub fn single_twiddle<T: FFTnum>(i: usize, fft_len: usize, inverse: bool) -> Complex<T> {
+pub fn single_twiddle<T: FftNum>(i: usize, fft_len: usize, inverse: bool) -> Complex<T> {
     let constant = if inverse {
         2f64 * f64::consts::PI
     } else {
@@ -26,7 +26,7 @@ pub fn single_twiddle<T: FFTnum>(i: usize, fft_len: usize, inverse: bool) -> Com
     }
 }
 
-pub fn rotate_90<T: FFTnum>(value: Complex<T>, inverse:bool) -> Complex<T>
+pub fn rotate_90<T: FftNum>(value: Complex<T>, inverse:bool) -> Complex<T>
 {
     if inverse {
         Complex{re:-value.im, im: value.re}

--- a/tests/accuracy.rs
+++ b/tests/accuracy.rs
@@ -15,8 +15,8 @@ use rustfft::num_traits::Zero;
 
 use rand::{StdRng, SeedableRng};
 use rand::distributions::{Normal, IndependentSample};
-use rustfft::{FFT, FFTplanner};
-use rustfft::algorithm::DFT;
+use rustfft::{Fft, FftPlanner};
+use rustfft::algorithm::Dft;
 
 /// The seed for the random number generator used to generate
 /// random signals. It's defined here so that we have deterministic
@@ -42,14 +42,14 @@ fn fft_matches_dft(signal: Vec<Complex<f32>>, inverse: bool) -> bool {
     let mut spectrum_dft = vec![Zero::zero(); signal.len()];
     let mut spectrum_fft = vec![Zero::zero(); signal.len()];
 
-    let mut planner = FFTplanner::new(inverse);
+    let mut planner = FftPlanner::new(inverse);
     let fft = planner.plan_fft(signal.len());
-    assert_eq!(fft.len(), signal.len(), "FFTplanner created FFT of wrong length");
-    assert_eq!(fft.is_inverse(), inverse, "FFTplanner created FFT of wrong direction");
+    assert_eq!(fft.len(), signal.len(), "FftPlanner created FFT of wrong length");
+    assert_eq!(fft.is_inverse(), inverse, "FftPlanner created FFT of wrong direction");
 
     fft.process(&mut signal_fft, &mut spectrum_fft);
 
-    let dft = DFT::new(signal.len(), inverse);
+    let dft = Dft::new(signal.len(), inverse);
     dft.process(&mut signal_dft, &mut spectrum_dft);
 
     return compare_vectors(&spectrum_dft[..], &spectrum_fft[..]);


### PR DESCRIPTION
This changes the following names to suit the [official rust naming
conventions](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html):

- `FFT` -> `Fft`
- `DFT` -> `Dft`
- `FFTButterfly` -> `FftButterfly`
- `FFTplanner` -> `FftPlanner`
- `FFTnum` -> `FftNum`

As this is a breaking change this should probably wait for a 3.0.0
release. Just thought I'd post it so that, if you agree with the
changes, it is ready when time for 3.0.0 comes :)

Closes #24.