### PR TITLE
bump rand and num-traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["fft", "dft", "fourier", "signal"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-num-complex = "0.1.36"
-num-traits = "0.1.37"
+num-complex = "0.1.42"
+num-traits = "0.2"
 
 [dev-dependencies]
-rand = "0.3.15"
+rand = "0.4"


### PR DESCRIPTION
Bump num-traits to 0.2, and rand to 0.4. No changes needed.

Additionally, force num-complex to the minimum version needed for new `num-traits`, so that nobody picks a different version.

Fixes #30.