### PR TITLE
Add explicit `dyn` to trait objects to remove deprecation warnings

### DIFF
--- a/benches/rustfft.rs
+++ b/benches/rustfft.rs
@@ -72,7 +72,7 @@ fn bench_good_thomas(b: &mut Bencher, width: usize, height: usize) {
     let width_fft = planner.plan_fft(width);
     let height_fft = planner.plan_fft(height);
 
-    let fft : Arc<FFT<_>> = Arc::new(GoodThomasAlgorithm::new(width_fft, height_fft));
+    let fft : Arc<dyn FFT<_>> = Arc::new(GoodThomasAlgorithm::new(width_fft, height_fft));
 
     let mut signal = vec![Complex{re: 0_f32, im: 0_f32}; width * height];
     let mut spectrum = signal.clone();
@@ -97,7 +97,7 @@ fn bench_good_thomas_setup(b: &mut Bencher, width: usize, height: usize) {
     let height_fft = planner.plan_fft(height);
 
     b.iter(|| { 
-        let fft : Arc<FFT<f32>> = Arc::new(GoodThomasAlgorithm::new(Arc::clone(&width_fft), Arc::clone(&height_fft)));
+        let fft : Arc<dyn FFT<f32>> = Arc::new(GoodThomasAlgorithm::new(Arc::clone(&width_fft), Arc::clone(&height_fft)));
         test::black_box(fft);
     });
 }
@@ -119,7 +119,7 @@ fn bench_mixed_radix(b: &mut Bencher, width: usize, height: usize) {
     let width_fft = planner.plan_fft(width);
     let height_fft = planner.plan_fft(height);
 
-    let fft : Arc<FFT<_>> = Arc::new(MixedRadix::new(width_fft, height_fft));
+    let fft : Arc<dyn FFT<_>> = Arc::new(MixedRadix::new(width_fft, height_fft));
 
     let mut signal = vec![Complex{re: 0_f32, im: 0_f32}; width * height];
     let mut spectrum = signal.clone();
@@ -137,7 +137,7 @@ fn bench_mixed_radix(b: &mut Bencher, width: usize, height: usize) {
 
 
 
-fn plan_butterfly(len: usize) -> Arc<FFTButterfly<f32>> {
+fn plan_butterfly(len: usize) -> Arc<dyn FFTButterfly<f32>> {
         match len {
             2 => Arc::new(Butterfly2::new(false)),
             3 => Arc::new(Butterfly3::new(false)),
@@ -159,7 +159,7 @@ fn bench_mixed_radix_butterfly(b: &mut Bencher, width: usize, height: usize) {
     let width_fft = plan_butterfly(width);
     let height_fft = plan_butterfly(height);
 
-    let fft : Arc<FFT<_>> = Arc::new(MixedRadixDoubleButterfly::new(width_fft, height_fft));
+    let fft : Arc<dyn FFT<_>> = Arc::new(MixedRadixDoubleButterfly::new(width_fft, height_fft));
 
     let mut signal = vec![Complex{re: 0_f32, im: 0_f32}; width * height];
     let mut spectrum = signal.clone();
@@ -178,7 +178,7 @@ fn bench_good_thomas_butterfly(b: &mut Bencher, width: usize, height: usize) {
     let width_fft = plan_butterfly(width);
     let height_fft = plan_butterfly(height);
 
-    let fft : Arc<FFT<_>> = Arc::new(GoodThomasAlgorithmDoubleButterfly::new(width_fft, height_fft));
+    let fft : Arc<dyn FFT<_>> = Arc::new(GoodThomasAlgorithmDoubleButterfly::new(width_fft, height_fft));
 
     let mut signal = vec![Complex{re: 0_f32, im: 0_f32}; width * height];
     let mut spectrum = signal.clone();
@@ -198,7 +198,7 @@ fn bench_raders(b: &mut Bencher, len: usize) {
     let mut planner = rustfft::FFTplanner::new(false);
     let inner_fft = planner.plan_fft(len - 1);
 
-    let fft : Arc<FFT<_>> = Arc::new(RadersAlgorithm::new(len, inner_fft));
+    let fft : Arc<dyn FFT<_>> = Arc::new(RadersAlgorithm::new(len, inner_fft));
 
     let mut signal = vec![Complex{re: 0_f32, im: 0_f32}; len];
     let mut spectrum = signal.clone();
@@ -222,7 +222,7 @@ fn bench_raders_setup(b: &mut Bencher, len: usize) {
     let inner_fft = planner.plan_fft(len - 1);
 
     b.iter(|| { 
-        let fft : Arc<FFT<f32>> = Arc::new(RadersAlgorithm::new(len, Arc::clone(&inner_fft)));
+        let fft : Arc<dyn FFT<f32>> = Arc::new(RadersAlgorithm::new(len, Arc::clone(&inner_fft)));
         test::black_box(fft);
     });
 }

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -1005,7 +1005,7 @@ mod unit_tests {
     test_butterfly_func!(test_butterfly32, Butterfly32, 32);
     
 
-    fn check_butterfly(butterfly: &FFTButterfly<f32>, size: usize, inverse: bool) {
+    fn check_butterfly(butterfly: &dyn FFTButterfly<f32>, size: usize, inverse: bool) {
         assert_eq!(butterfly.len(), size, "Butterfly algorithm reported wrong size");
         assert_eq!(butterfly.is_inverse(), inverse, "Butterfly algorithm reported wrong inverse value");
 

--- a/src/algorithm/good_thomas_algorithm.rs
+++ b/src/algorithm/good_thomas_algorithm.rs
@@ -42,10 +42,10 @@ use algorithm::butterflies::FFTButterfly;
 /// ~~~
 pub struct GoodThomasAlgorithm<T> {
     width: usize,
-    width_size_fft: Arc<FFT<T>>,
+    width_size_fft: Arc<dyn FFT<T>>,
 
     height: usize,
-    height_size_fft: Arc<FFT<T>>,
+    height_size_fft: Arc<dyn FFT<T>>,
 
     input_x_stride: usize,
     input_y_stride: usize,
@@ -58,7 +58,7 @@ impl<T: FFTnum> GoodThomasAlgorithm<T> {
     /// Creates a FFT instance which will process inputs/outputs of size `width_fft.len() * height_fft.len()`
     ///
     /// GCD(width_fft.len(), height_fft.len()) must be equal to 1
-    pub fn new(width_fft: Arc<FFT<T>>, height_fft: Arc<FFT<T>>) -> Self {
+    pub fn new(width_fft: Arc<dyn FFT<T>>, height_fft: Arc<dyn FFT<T>>) -> Self {
         assert_eq!(
             width_fft.is_inverse(), height_fft.is_inverse(), 
             "width_fft and height_fft must both be inverse, or neither. got width inverse={}, height inverse={}",
@@ -190,10 +190,10 @@ impl<T> IsInverse for GoodThomasAlgorithm<T> {
 /// ~~~
 pub struct GoodThomasAlgorithmDoubleButterfly<T> {
     width: usize,
-    width_size_fft: Arc<FFTButterfly<T>>,
+    width_size_fft: Arc<dyn FFTButterfly<T>>,
 
     height: usize,
-    height_size_fft: Arc<FFTButterfly<T>>,
+    height_size_fft: Arc<dyn FFTButterfly<T>>,
 
     input_output_map: Box<[usize]>,
 
@@ -204,7 +204,7 @@ impl<T: FFTnum> GoodThomasAlgorithmDoubleButterfly<T> {
     /// Creates a FFT instance which will process inputs/outputs of size `width_fft.len() * height_fft.len()`
     ///
     /// GCD(n1.len(), n2.len()) must be equal to 1
-    pub fn new(width_fft: Arc<FFTButterfly<T>>, height_fft: Arc<FFTButterfly<T>>) -> Self {
+    pub fn new(width_fft: Arc<dyn FFTButterfly<T>>, height_fft: Arc<dyn FFTButterfly<T>>) -> Self {
         assert_eq!(
             width_fft.is_inverse(), height_fft.is_inverse(), 
             "n1_fft and height_fft must both be inverse, or neither. got width inverse={}, height inverse={}",
@@ -341,8 +341,8 @@ mod unit_tests {
     }
 
     fn test_good_thomas_with_lengths(width: usize, height: usize, inverse: bool) {
-        let width_fft = Arc::new(DFT::new(width, inverse)) as Arc<FFT<f32>>;
-        let height_fft = Arc::new(DFT::new(height, inverse)) as Arc<FFT<f32>>;
+        let width_fft = Arc::new(DFT::new(width, inverse)) as Arc<dyn FFT<f32>>;
+        let height_fft = Arc::new(DFT::new(height, inverse)) as Arc<dyn FFT<f32>>;
 
         let fft = GoodThomasAlgorithm::new(width_fft, height_fft);
 

--- a/src/algorithm/mixed_radix.rs
+++ b/src/algorithm/mixed_radix.rs
@@ -38,10 +38,10 @@ use twiddles;
 
 pub struct MixedRadix<T> {
     width: usize,
-    width_size_fft: Arc<FFT<T>>,
+    width_size_fft: Arc<dyn FFT<T>>,
 
     height: usize,
-    height_size_fft: Arc<FFT<T>>,
+    height_size_fft: Arc<dyn FFT<T>>,
 
     twiddles: Box<[Complex<T>]>,
     inverse: bool,
@@ -49,7 +49,7 @@ pub struct MixedRadix<T> {
 
 impl<T: FFTnum> MixedRadix<T> {
     /// Creates a FFT instance which will process inputs/outputs of size `width_fft.len() * height_fft.len()`
-    pub fn new(width_fft: Arc<FFT<T>>, height_fft: Arc<FFT<T>>) -> Self {
+    pub fn new(width_fft: Arc<dyn FFT<T>>, height_fft: Arc<dyn FFT<T>>) -> Self {
         assert_eq!(
             width_fft.is_inverse(), height_fft.is_inverse(), 
             "width_fft and height_fft must both be inverse, or neither. got width inverse={}, height inverse={}",
@@ -164,10 +164,10 @@ impl<T> IsInverse for MixedRadix<T> {
 /// ~~~
 pub struct MixedRadixDoubleButterfly<T> {
     width: usize,
-    width_size_fft: Arc<FFTButterfly<T>>,
+    width_size_fft: Arc<dyn FFTButterfly<T>>,
 
     height: usize,
-    height_size_fft: Arc<FFTButterfly<T>>,
+    height_size_fft: Arc<dyn FFTButterfly<T>>,
 
     twiddles: Box<[Complex<T>]>,
     inverse: bool,
@@ -175,7 +175,7 @@ pub struct MixedRadixDoubleButterfly<T> {
 
 impl<T: FFTnum> MixedRadixDoubleButterfly<T> {
     /// Creates a FFT instance which will process inputs/outputs of size `width_fft.len() * height_fft.len()`
-    pub fn new(width_fft: Arc<FFTButterfly<T>>, height_fft: Arc<FFTButterfly<T>>) -> Self {
+    pub fn new(width_fft: Arc<dyn FFTButterfly<T>>, height_fft: Arc<dyn FFTButterfly<T>>) -> Self {
         assert_eq!(
             width_fft.is_inverse(), height_fft.is_inverse(), 
             "width_fft and height_fft must both be inverse, or neither. got width inverse={}, height inverse={}",
@@ -294,8 +294,8 @@ mod unit_tests {
 
 
     fn test_mixed_radix_with_lengths(width: usize, height: usize, inverse: bool) {
-        let width_fft = Arc::new(DFT::new(width, inverse)) as Arc<FFT<f32>>;
-        let height_fft = Arc::new(DFT::new(height, inverse)) as Arc<FFT<f32>>;
+        let width_fft = Arc::new(DFT::new(width, inverse)) as Arc<dyn FFT<f32>>;
+        let height_fft = Arc::new(DFT::new(height, inverse)) as Arc<dyn FFT<f32>>;
 
         let fft = MixedRadix::new(width_fft, height_fft);
 

--- a/src/algorithm/raders_algorithm.rs
+++ b/src/algorithm/raders_algorithm.rs
@@ -41,7 +41,7 @@ use ::{Length, IsInverse, FFT};
 /// that it takes 2.5x more time to compute than a FFT of size 1200.
 
 pub struct RadersAlgorithm<T> {
-    inner_fft: Arc<FFT<T>>,
+    inner_fft: Arc<dyn FFT<T>>,
     inner_fft_data: Box<[Complex<T>]>,
 
     primitive_root: usize,
@@ -58,7 +58,7 @@ impl<T: FFTnum> RadersAlgorithm<T> {
     /// FFT algorithms
     ///
     /// Note also that if `len` is not prime, this algorithm may silently produce garbage output
-    pub fn new(len: usize, inner_fft: Arc<FFT<T>>) -> Self {
+    pub fn new(len: usize, inner_fft: Arc<dyn FFT<T>>) -> Self {
         assert_eq!(len - 1, inner_fft.len(), "For raders algorithm, inner_fft.len() must be self.len() - 1. Expected {}, got {}", len - 1, inner_fft.len());
 
         let inner_fft_len = len - 1;

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -70,7 +70,7 @@ impl<T: FFTnum> Radix4<T> {
 
     fn perform_fft(&self, signal: &[Complex<T>], spectrum: &mut [Complex<T>]) {
         match self.len() {
-            0...1 => spectrum.copy_from_slice(signal),
+            0..=1 => spectrum.copy_from_slice(signal),
             2 => {
                 spectrum.copy_from_slice(signal);
                 unsafe { Butterfly2::new(self.inverse).process_inplace(spectrum) }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -48,8 +48,8 @@ const COMPOSITE_BUTTERFLIES: [usize; 5] = [4, 6, 8, 16, 32];
 /// safe to drop the planner after creating FFT instances.
 pub struct FFTplanner<T> {
     inverse: bool,
-    algorithm_cache: HashMap<usize, Arc<FFT<T>>>,
-    butterfly_cache: HashMap<usize, Arc<FFTButterfly<T>>>,
+    algorithm_cache: HashMap<usize, Arc<dyn FFT<T>>>,
+    butterfly_cache: HashMap<usize, Arc<dyn FFTButterfly<T>>>,
 }
 
 impl<T: FFTnum> FFTplanner<T> {
@@ -66,16 +66,16 @@ impl<T: FFTnum> FFTplanner<T> {
 
     /// Returns a FFT instance which processes signals of size `len`
     /// If this is called multiple times, it will attempt to re-use internal data between instances
-    pub fn plan_fft(&mut self, len: usize) -> Arc<FFT<T>> {
+    pub fn plan_fft(&mut self, len: usize) -> Arc<dyn FFT<T>> {
         if len < 2 {
-            Arc::new(DFT::new(len, self.inverse)) as Arc<FFT<T>>
+            Arc::new(DFT::new(len, self.inverse)) as Arc<dyn FFT<T>>
         } else {
             let factors = math_utils::prime_factors(len);
             self.plan_fft_with_factors(len, &factors)
         }
     }
 
-    fn plan_butterfly(&mut self, len: usize) -> Arc<FFTButterfly<T>> {
+    fn plan_butterfly(&mut self, len: usize) -> Arc<dyn FFTButterfly<T>> {
         let inverse = self.inverse;
         let instance = self.butterfly_cache.entry(len).or_insert_with(|| 
             match len {
@@ -94,7 +94,7 @@ impl<T: FFTnum> FFTplanner<T> {
         Arc::clone(instance)
     }
     
-    fn plan_fft_with_factors(&mut self, len: usize, factors: &[usize]) -> Arc<FFT<T>> {
+    fn plan_fft_with_factors(&mut self, len: usize, factors: &[usize]) -> Arc<dyn FFT<T>> {
         if self.algorithm_cache.contains_key(&len) {
             Arc::clone(self.algorithm_cache.get(&len).unwrap())
         } else {
@@ -164,7 +164,7 @@ impl<T: FFTnum> FFTplanner<T> {
                         left_factors: &[usize],
                         right_len: usize,
                         right_factors: &[usize])
-                        -> Arc<FFT<T>> {
+                        -> Arc<dyn FFT<T>> {
 
         let left_is_butterfly = BUTTERFLIES.contains(&left_len);
         let right_is_butterfly = BUTTERFLIES.contains(&right_len);
@@ -176,42 +176,42 @@ impl<T: FFTnum> FFTplanner<T> {
 
             // for butterflies, if gcd is 1, we always want to use good-thomas
             if gcd(left_len, right_len) == 1 {
-                Arc::new(GoodThomasAlgorithmDoubleButterfly::new(left_fft, right_fft)) as Arc<FFT<T>>
+                Arc::new(GoodThomasAlgorithmDoubleButterfly::new(left_fft, right_fft)) as Arc<dyn FFT<T>>
             } else {
-                Arc::new(MixedRadixDoubleButterfly::new(left_fft, right_fft)) as Arc<FFT<T>>
+                Arc::new(MixedRadixDoubleButterfly::new(left_fft, right_fft)) as Arc<dyn FFT<T>>
             }
         } else {
             //neither size is a butterfly, so go with the normal algorithm
             let left_fft = self.plan_fft_with_factors(left_len, left_factors);
             let right_fft = self.plan_fft_with_factors(right_len, right_factors);
 
-            Arc::new(MixedRadix::new(left_fft, right_fft)) as Arc<FFT<T>>
+            Arc::new(MixedRadix::new(left_fft, right_fft)) as Arc<dyn FFT<T>>
         }
     }
 
 
-    fn plan_fft_single_factor(&mut self, len: usize) -> Arc<FFT<T>> {
-        match len {
-            0...1 => Arc::new(DFT::new(len, self.inverse)) as Arc<FFT<T>>,
-            2 => Arc::new(butterflies::Butterfly2::new(self.inverse)) as Arc<FFT<T>>,
-            3 => Arc::new(butterflies::Butterfly3::new(self.inverse)) as Arc<FFT<T>>,
-            4 => Arc::new(butterflies::Butterfly4::new(self.inverse)) as Arc<FFT<T>>,
-            5 => Arc::new(butterflies::Butterfly5::new(self.inverse)) as Arc<FFT<T>>,
-            6 => Arc::new(butterflies::Butterfly6::new(self.inverse)) as Arc<FFT<T>>,
-            7 => Arc::new(butterflies::Butterfly7::new(self.inverse)) as Arc<FFT<T>>,
-            8 => Arc::new(butterflies::Butterfly8::new(self.inverse)) as Arc<FFT<T>>,
-            16 => Arc::new(butterflies::Butterfly16::new(self.inverse)) as Arc<FFT<T>>,
-            32 => Arc::new(butterflies::Butterfly32::new(self.inverse)) as Arc<FFT<T>>,
+    fn plan_fft_single_factor(&mut self, len: usize) -> Arc<dyn FFT<T>> {
+    match len {
+            0..=1 => Arc::new(DFT::new(len, self.inverse)) as Arc<dyn FFT<T>>,
+            2 => Arc::new(butterflies::Butterfly2::new(self.inverse)) as Arc<dyn FFT<T>>,
+            3 => Arc::new(butterflies::Butterfly3::new(self.inverse)) as Arc<dyn FFT<T>>,
+            4 => Arc::new(butterflies::Butterfly4::new(self.inverse)) as Arc<dyn FFT<T>>,
+            5 => Arc::new(butterflies::Butterfly5::new(self.inverse)) as Arc<dyn FFT<T>>,
+            6 => Arc::new(butterflies::Butterfly6::new(self.inverse)) as Arc<dyn FFT<T>>,
+            7 => Arc::new(butterflies::Butterfly7::new(self.inverse)) as Arc<dyn FFT<T>>,
+            8 => Arc::new(butterflies::Butterfly8::new(self.inverse)) as Arc<dyn FFT<T>>,
+            16 => Arc::new(butterflies::Butterfly16::new(self.inverse)) as Arc<dyn FFT<T>>,
+            32 => Arc::new(butterflies::Butterfly32::new(self.inverse)) as Arc<dyn FFT<T>>,
             _ => self.plan_prime(len),
         }
     }
 
-    fn plan_prime(&mut self, len: usize) -> Arc<FFT<T>> {
+    fn plan_prime(&mut self, len: usize) -> Arc<dyn FFT<T>> {
         let inner_fft_len = len - 1;
         let factors = math_utils::prime_factors(inner_fft_len);
 
         let inner_fft = self.plan_fft_with_factors(inner_fft_len, &factors);
 
-        Arc::new(RadersAlgorithm::new(len, inner_fft)) as Arc<FFT<T>>
+        Arc::new(RadersAlgorithm::new(len, inner_fft)) as Arc<dyn FFT<T>>
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -36,7 +36,7 @@ pub fn compare_vectors(vec1: &[Complex<f32>], vec2: &[Complex<f32>]) -> bool {
     return (sse / vec1.len() as f32) < 0.1f32;
 }
 
-pub fn check_fft_algorithm(fft: &FFT<f32>, size: usize, inverse: bool) {
+pub fn check_fft_algorithm(fft: &dyn FFT<f32>, size: usize, inverse: bool) {
     assert_eq!(fft.len(), size, "Algorithm reported incorrect size");
     assert_eq!(fft.is_inverse(), inverse, "Algorithm reported incorrect inverse value");
 
@@ -66,7 +66,7 @@ pub fn check_fft_algorithm(fft: &FFT<f32>, size: usize, inverse: bool) {
     assert!(compare_vectors(&expected_output, &multi_output), "process_multi() failed, length = {}, inverse = {}", size, inverse);
 }
 
-pub fn make_butterfly(len: usize, inverse: bool) -> Arc<butterflies::FFTButterfly<f32>> {
+pub fn make_butterfly(len: usize, inverse: bool) -> Arc<dyn butterflies::FFTButterfly<f32>> {
     match len {
         2 => Arc::new(butterflies::Butterfly2::new(inverse)),
         3 => Arc::new(butterflies::Butterfly3::new(inverse)),


### PR DESCRIPTION
this patch adds `dyn` keyword to remove the deprecation warnings