### PR TITLE
Bump num-complex to 0.3, transpose to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ categories = ["algorithms", "compression", "multimedia::encoding", "science"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-num-complex = "0.2"
+num-complex = "0.3"
+num-integer = "0.1.43"
 num-traits = "0.2"
-num-integer = "0.1"
 strength_reduce = "^0.2.1"
-transpose = "0.1"
+transpose = "0.2"
 
 [dev-dependencies]
 rand = "0.5"

--- a/src/algorithm/dft.rs
+++ b/src/algorithm/dft.rs
@@ -100,7 +100,7 @@ mod unit_tests {
             let mut sum = Zero::zero();
             for (i, &x) in signal.iter().enumerate() {
                 let angle = -1f32 * (i * k) as f32 * 2f32 * f32::consts::PI / signal.len() as f32;
-                let twiddle = Complex::from_polar(&1f32, &angle);
+                let twiddle = Complex::from_polar(1f32, angle);
 
                 sum = sum + twiddle * x;
             }

--- a/src/twiddles.rs
+++ b/src/twiddles.rs
@@ -18,7 +18,7 @@ pub fn single_twiddle<T: FFTnum>(i: usize, fft_len: usize, inverse: bool) -> Com
         -2f64 * f64::consts::PI
     };
 
-    let c = Complex::from_polar(&One::one(), &(constant * i as f64 / fft_len as f64));
+    let c = Complex::from_polar(One::one(), constant * i as f64 / fft_len as f64);
 
     Complex {
         re: FromPrimitive::from_f64(c.re).unwrap(),
@@ -51,7 +51,7 @@ mod unit_tests {
 
         for len in 1..10 {
             let actual: Vec<Complex<f32>> = generate_twiddle_factors(len, false);
-            let expected: Vec<Complex<f32>> = (0..len).map(|i| Complex::from_polar(&1f32, &(constant * i as f32 / len as f32))).collect();
+            let expected: Vec<Complex<f32>> = (0..len).map(|i| Complex::from_polar(1f32, constant * i as f32 / len as f32)).collect();
 
             assert!(compare_vectors(&actual, &expected), "len = {}", len)
         }


### PR DESCRIPTION
num-complex 0.3 has been available for a while so it would be nice to upgrade. This PR updates num-complex to 0.3, and transpose to 0.2.
The only noticable change is that Complex::from_polar now wants numbers and not references.