### PR TITLE
Add github action for check and test

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -1,0 +1,35 @@
+on: [push, pull_request]
+
+name: CI test and lint
+
+jobs:
+  check:
+    name: Run check and test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+          - 1.31.0 
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test


### PR DESCRIPTION
Since travis-ci.org will close at the end of the year, the CI need to move. This PR adds a github action that runs "cargo check" and "cargo test", for 1.31, stable, beta and nightly. I put 1.31 since it's the minimum one supported by num-complex 0.3, see https://github.com/awelkie/RustFFT/pull/60.