### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 num-complex = "0.2"
 num-traits = "0.2"
 num-integer = "0.1"
-strength_reduce = "^0.2.1"
+strength_reduce = "0.2.3"
 transpose = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
strength_reduce 0.2.1 and 0.2.2 do not have 'StrengthReducedU128' in their root module so you cannot compile RustFFT on those versions. should enforce strength_reduce version of 0.2.3.